### PR TITLE
chore: Make repository public

### DIFF
--- a/.pallet/gitconfig.yaml
+++ b/.pallet/gitconfig.yaml
@@ -7,6 +7,7 @@ metadata:
   name: repository-config
 spec:
   description: Mage CI targets
+  visibility: public
   branches:
     default: main
     protection:


### PR DESCRIPTION
In order to use our mage setup in public repositories we must make it public.
Having this repository public is a good way of showing how we work.
