### PR TITLE
feat: Cache downloaded Go modules on host machine

### DIFF
--- a/internal/devtool/devtool.go
+++ b/internal/devtool/devtool.go
@@ -37,9 +37,15 @@ func RunWith(env map[string]string, tool, cmd string, args ...string) error {
 		return err
 	}
 
+	goModCache, err := sh.Output("go", "env", "GOMODCACHE")
+	if err != nil {
+		return err
+	}
+
 	call := []string{
 		"run",
 		"--rm",
+		"-v", fmt.Sprintf("%s:/go/pkg/mod", goModCache),
 		"-v", "/var/run/docker.sock:/var/run/docker.sock",
 		"-v", "$HOME/.cache:/root/.cache",
 		"-v", "$HOME/.gitconfig:/root/.gitconfig",

--- a/internal/golang/golang.go
+++ b/internal/golang/golang.go
@@ -3,6 +3,7 @@ package golang
 import (
 	"fmt"
 	"io/fs"
+	"log"
 	"os"
 	"path"
 	"path/filepath"
@@ -128,4 +129,10 @@ func LintFix(directory, golangCILintCfg string) error {
 		return err
 	}
 	return devtool.Run("golangci-lint", "bash", "-c", fmt.Sprintf("cd %s && golangci-lint run --verbose --timeout 5m --fix --config %s ./...", directory, lintCfgPath))
+}
+
+// DownloadModules downloads Go modules locally
+func DownloadModules(directory string) error {
+	log.Printf("Downloading modules for dir %q", directory)
+	return devtool.Run("golang", "go", "-C", directory, "mod", "download", "-x")
 }

--- a/targets/goapp/golang.go
+++ b/targets/goapp/golang.go
@@ -104,6 +104,7 @@ func (Go) Generate(ctx context.Context) error {
 //	                ├── dataloader
 //	                └── server
 func (Go) Build(ctx context.Context) error {
+	mg.CtxDeps(ctx, golangTargets.DownloadModules)
 	mg.CtxDeps(ctx, Go.Validate)
 
 	rootPath, err := os.Getwd()


### PR DESCRIPTION
This change attempts to shorten the feedback loop by:

- mounting the host machine's GOMODCACHE directory into the Go container used
  to run tests and compiling code.
- downloading Go module before running test and validation targets


Co-authored-by: Bendik Nesbø <bendik.august.nesbo@coop.no>