### PR TITLE
refactor: Remove go:run target for goapps

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,7 @@ import (
 
 #### Targets for Go apps
 
-- [X] Go run
+- [ ] Go run
 - [X] Go build
 - [X] Go tests
 - [X] Go linting

--- a/targets/goapp/golang.go
+++ b/targets/goapp/golang.go
@@ -187,12 +187,6 @@ func (Go) build(ctx context.Context, workingDirectory, input, output, goos, goar
 		input)
 }
 
-// Run runs a cmd: mage run <cmd>
-func (Go) Run(ctx context.Context, workingDirectory, bin string) error {
-	mg.CtxDeps(ctx, Go.Validate, mg.F(devtoolTarget.Build, "golang", golangTargets.GolangToolsDockerfile))
-	return devtool.Run("golang", "go", "-C", workingDirectory, "run", fmt.Sprintf("%s/%s/main.go", cmdDir, bin))
-}
-
 // Validate runs validation check on the Go source code in the repository.
 //
 // For details see [Go.Test] and [Go.Lint].


### PR DESCRIPTION
The `go:run` target was prematurely added. The target does not allow for
loading configuration and secrets required to start the application.

We need to solve the referenced issues before adding back the `go:run` target.

Ref:
- https://github.com/coopnorge/mage/issues/125
- https://github.com/coopnorge/engineering-issues/issues/443
