### PR TITLE
chore: rework devtool package to make it more generic

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -56,6 +56,7 @@ import (
 - [ ] Go mock generation
 - [X] Docker image build
 - [X] Docker image push
+- [ ] Terraform CI
 - [ ] Techdocs CI
 - [ ] Kubernetes CI
 - [ ] Security Scanning

--- a/internal/devtool/devtool.go
+++ b/internal/devtool/devtool.go
@@ -37,10 +37,10 @@ func RunWith(env map[string]string, tool string, dockerRunArgs []string, cmd str
 		"--rm",
 	}
 
-		    call = append(call, dockerRunArgs...)
+	call = append(call, dockerRunArgs...)
 	call = append(call, image, cmd)
 	call = append(call, args...)
-	return sh.RunWithV(env,"docker", call...)
+	return sh.RunWithV(env, "docker", call...)
 }
 
 // Build allow a mage target to depend on a Docker image. This will

--- a/internal/golang/golang.go
+++ b/internal/golang/golang.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/magefile/mage/sh"
+
 	"github.com/coopnorge/mage/internal/core"
 	"github.com/coopnorge/mage/internal/devtool"
 )
@@ -66,7 +68,7 @@ func isDotDirectory(path string, d fs.DirEntry) bool {
 // the intent to generate Go code. Those commands can run any process but the
 // intent is to create or update Go source files
 func Generate(directory string) error {
-	return devtool.Run("golang", "go", "-C", directory, "generate", "./...")
+	return devtoolGo("go","-C", directory,"generate","./...")
 }
 
 // Test automates testing the packages named by the import paths, see also: go
@@ -87,17 +89,8 @@ func Test(directory string) error {
 	}
 
 	output := path.Join(relativeRootPath, core.OutputDir, directory, coverageReport)
-	return devtool.Run(
-		"golang",
-		"go",
-		"-C", directory,
-		"test",
-		"--cover",
-		fmt.Sprintf("-coverprofile=%s", output),
-		"-covermode=atomic",
-		"-race",
-		"-tags='datadog.no_waf'",
-		"./...")
+
+	return devtoolGo("go","-C", directory, "test", "--cover", fmt.Sprintf("-coverprofile=%s", output), "-covermode=atomic", "-race", "-tags='datadog.no_waf'", "./...")
 }
 
 // Lint runs the linters
@@ -113,7 +106,7 @@ func Lint(directory, golangCILintCfg string) error {
 		return err
 	}
 
-	return devtool.Run("golangci-lint", "bash", "-c", fmt.Sprintf("cd %s && golangci-lint run --verbose --timeout 5m --config %s ./...", directory, lintCfgPath))
+    return devtoolGolangCILint("bash","-c",fmt.Sprintf("cd %s && golangci-lint run --verbose --timeout 5m --config %s ./...", directory, lintCfgPath))
 }
 
 // LintFix fixes found issues (if it's supported by the linters)
@@ -128,11 +121,58 @@ func LintFix(directory, golangCILintCfg string) error {
 	if err != nil {
 		return err
 	}
-	return devtool.Run("golangci-lint", "bash", "-c", fmt.Sprintf("cd %s && golangci-lint run --verbose --timeout 5m --fix --config %s ./...", directory, lintCfgPath))
+    return devtoolGolangCILint("bash","-c",fmt.Sprintf("cd %s && golangci-lint run --verbose --timeout 5m --fix --config %s ./...", directory, lintCfgPath))
 }
 
 // DownloadModules downloads Go modules locally
 func DownloadModules(directory string) error {
 	log.Printf("Downloading modules for dir %q", directory)
-	return devtool.Run("golang", "go", "-C", directory, "mod", "download", "-x")
+	return devtoolGo("go","-C", directory,"mod","download","-x")
 }
+
+func devtoolGo(cmd string, args... string) error {
+     path, err := os.Getwd()
+	 if err != nil {
+		 return err
+	 }
+
+	 goModCache, err := sh.Output("go", "env", "GOMODCACHE")
+	 if err != nil {
+	   goModCache = "$HOME/go/pkg/mod"
+	 }
+
+	 dockerArgs := []string{
+     "--volume", fmt.Sprintf("%s:/go/pkg/mod", goModCache),
+     "--volume", "/var/run/docker.sock:/var/run/docker.sock",
+     "--volume", "$HOME/.cache:/root/.cache",
+     "--volume", "$HOME/.gitconfig:/root/.gitconfig",
+     "--volume", "$HOME/.ssh:/root/.ssh",
+     "--env", "TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal",
+     "--add-host", "host.docker.internal:host-gateway",
+     "--volume", fmt.Sprintf("%s:/app", path),
+     "--workdir", "/app",
+   }
+
+   return devtool.Run("golang",dockerArgs,cmd, args... )
+}
+
+func devtoolGolangCILint(cmd string , args... string) error {
+     path, err := os.Getwd()
+	 if err != nil {
+		 return err
+	 }
+
+	 goModCache, err := sh.Output("go", "env", "GOMODCACHE")
+	 if err != nil {
+	   goModCache = "$HOME/go/pkg/mod"
+	 }
+
+	 dockerArgs := []string{
+     "--volume", fmt.Sprintf("%s:/go/pkg/mod", goModCache),
+     "--volume", fmt.Sprintf("%s:/app", path),
+     "--workdir", "/app",
+   }
+
+   return devtool.Run("golangci-lint", dockerArgs,cmd,args...)
+}
+

--- a/internal/golang/golang.go
+++ b/internal/golang/golang.go
@@ -68,7 +68,7 @@ func isDotDirectory(path string, d fs.DirEntry) bool {
 // the intent to generate Go code. Those commands can run any process but the
 // intent is to create or update Go source files
 func Generate(directory string) error {
-	return devtoolGo("go","-C", directory,"generate","./...")
+	return DevtoolGo(nil, "go", "-C", directory, "generate", "./...")
 }
 
 // Test automates testing the packages named by the import paths, see also: go
@@ -90,7 +90,7 @@ func Test(directory string) error {
 
 	output := path.Join(relativeRootPath, core.OutputDir, directory, coverageReport)
 
-	return devtoolGo("go","-C", directory, "test", "--cover", fmt.Sprintf("-coverprofile=%s", output), "-covermode=atomic", "-race", "-tags='datadog.no_waf'", "./...")
+	return DevtoolGo(nil, "go", "-C", directory, "test", "--cover", fmt.Sprintf("-coverprofile=%s", output), "-covermode=atomic", "-race", "-tags='datadog.no_waf'", "./...")
 }
 
 // Lint runs the linters
@@ -106,7 +106,7 @@ func Lint(directory, golangCILintCfg string) error {
 		return err
 	}
 
-    return devtoolGolangCILint("bash","-c",fmt.Sprintf("cd %s && golangci-lint run --verbose --timeout 5m --config %s ./...", directory, lintCfgPath))
+	return DevtoolGolangCILint(nil, "bash", "-c", fmt.Sprintf("cd %s && golangci-lint run --verbose --timeout 5m --config %s ./...", directory, lintCfgPath))
 }
 
 // LintFix fixes found issues (if it's supported by the linters)
@@ -121,58 +121,73 @@ func LintFix(directory, golangCILintCfg string) error {
 	if err != nil {
 		return err
 	}
-    return devtoolGolangCILint("bash","-c",fmt.Sprintf("cd %s && golangci-lint run --verbose --timeout 5m --fix --config %s ./...", directory, lintCfgPath))
+	return DevtoolGolangCILint(nil, "bash", "-c", fmt.Sprintf("cd %s && golangci-lint run --verbose --timeout 5m --fix --config %s ./...", directory, lintCfgPath))
 }
 
 // DownloadModules downloads Go modules locally
 func DownloadModules(directory string) error {
 	log.Printf("Downloading modules for dir %q", directory)
-	return devtoolGo("go","-C", directory,"mod","download","-x")
+	return DevtoolGo(nil, "go", "-C", directory, "mod", "download", "-x")
 }
 
-func devtoolGo(cmd string, args... string) error {
-     path, err := os.Getwd()
-	 if err != nil {
-		 return err
-	 }
+// DevtoolGo runs the devtool for Go
+func DevtoolGo(env map[string]string, cmd string, args ...string) error {
+	path, err := os.Getwd()
+	if err != nil {
+		return err
+	}
 
-	 goModCache, err := sh.Output("go", "env", "GOMODCACHE")
-	 if err != nil {
-	   goModCache = "$HOME/go/pkg/mod"
-	 }
+	goModCache, err := sh.Output("go", "env", "GOMODCACHE")
+	if err != nil {
+		goModCache = "$HOME/go/pkg/mod"
+	}
 
-	 dockerArgs := []string{
-     "--volume", fmt.Sprintf("%s:/go/pkg/mod", goModCache),
-     "--volume", "/var/run/docker.sock:/var/run/docker.sock",
-     "--volume", "$HOME/.cache:/root/.cache",
-     "--volume", "$HOME/.gitconfig:/root/.gitconfig",
-     "--volume", "$HOME/.ssh:/root/.ssh",
-     "--env", "TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal",
-     "--add-host", "host.docker.internal:host-gateway",
-     "--volume", fmt.Sprintf("%s:/app", path),
-     "--workdir", "/app",
-   }
+	dockerArgs := []string{
+		"--volume", fmt.Sprintf("%s:/go/pkg/mod", goModCache),
+		"--volume", "/var/run/docker.sock:/var/run/docker.sock",
+		"--volume", "$HOME/.cache:/root/.cache",
+		"--volume", "$HOME/.gitconfig:/root/.gitconfig",
+		"--volume", "$HOME/.ssh:/root/.ssh",
+		"--env", "TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal",
+		"--add-host", "host.docker.internal:host-gateway",
+		"--volume", fmt.Sprintf("%s:/app", path),
+		"--workdir", "/app",
+	}
 
-   return devtool.Run("golang",dockerArgs,cmd, args... )
+	if env == nil {
+		env = map[string]string{}
+	}
+	for k, v := range env {
+		dockerArgs = append(dockerArgs, "--env", fmt.Sprintf("%s=%s", k, v))
+	}
+
+	return devtool.Run("golang", dockerArgs, cmd, args...)
 }
 
-func devtoolGolangCILint(cmd string , args... string) error {
-     path, err := os.Getwd()
-	 if err != nil {
-		 return err
-	 }
+// DevtoolGolangCILint runs the devtool for Golangci-lint
+func DevtoolGolangCILint(env map[string]string, cmd string, args ...string) error {
+	path, err := os.Getwd()
+	if err != nil {
+		return err
+	}
 
-	 goModCache, err := sh.Output("go", "env", "GOMODCACHE")
-	 if err != nil {
-	   goModCache = "$HOME/go/pkg/mod"
-	 }
+	goModCache, err := sh.Output("go", "env", "GOMODCACHE")
+	if err != nil {
+		goModCache = "$HOME/go/pkg/mod"
+	}
 
-	 dockerArgs := []string{
-     "--volume", fmt.Sprintf("%s:/go/pkg/mod", goModCache),
-     "--volume", fmt.Sprintf("%s:/app", path),
-     "--workdir", "/app",
-   }
+	dockerArgs := []string{
+		"--volume", fmt.Sprintf("%s:/go/pkg/mod", goModCache),
+		"--volume", fmt.Sprintf("%s:/app", path),
+		"--workdir", "/app",
+	}
 
-   return devtool.Run("golangci-lint", dockerArgs,cmd,args...)
+	if env == nil {
+		env = map[string]string{}
+	}
+	for k, v := range env {
+		dockerArgs = append(dockerArgs, "--env", fmt.Sprintf("%s=%s", k, v))
+	}
+
+	return devtool.Run("golangci-lint", dockerArgs, cmd, args...)
 }
-

--- a/targets/goapp/golang.go
+++ b/targets/goapp/golang.go
@@ -7,7 +7,6 @@ import (
 	"path"
 
 	"github.com/coopnorge/mage/internal/core"
-	"github.com/coopnorge/mage/internal/devtool"
 	"github.com/coopnorge/mage/internal/golang"
 	devtoolTarget "github.com/coopnorge/mage/internal/targets/devtool"
 	golangTargets "github.com/coopnorge/mage/internal/targets/golang"
@@ -175,11 +174,11 @@ func (Go) build(ctx context.Context, workingDirectory, input, output, goos, goar
 
 	environmentalVariables := map[string]string{"GOOS": goos, "GOARCH": goarch, "CGO_ENABLED": "0"}
 
-	return devtool.RunWith(
+	return golang.DevtoolGo(
 		environmentalVariables,
-		"golang",
 		"go",
-		"-C", workingDirectory,
+		"-C",
+		workingDirectory,
 		"build",
 		"-v",
 		"-tags='datadog.no_waf'",


### PR DESCRIPTION
In the initial version the devtool package was implemented with only golang devtools in mind. This PR will move the Go related stuff into the internal Go package.
