### PR TITLE
build: Revert to Go 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/coopnorge/mage
 
-go 1.24.0
+go 1.23.0
+
+toolchain go1.24.0
 
 require (
 	github.com/magefile/mage v1.15.0

--- a/internal/targets/terraform/terraform_test.go
+++ b/internal/targets/terraform/terraform_test.go
@@ -7,6 +7,7 @@ import (
 	"text/template"
 
 	"github.com/coopnorge/mage/internal/core"
+	"github.com/coopnorge/mage/internal/testhelpers"
 	"github.com/magefile/mage/sh"
 	"github.com/stretchr/testify/assert"
 )
@@ -129,7 +130,7 @@ func TestTargets(t *testing.T) {
 				panic(err)
 			}
 
-			t.Chdir(dir)
+			testhelpers.Chdir(t, dir)
 
 			goMod, err := os.Create("go.mod")
 			if err != nil {

--- a/internal/terraform/terraform_test.go
+++ b/internal/terraform/terraform_test.go
@@ -9,13 +9,13 @@ import (
 
 	"github.com/coopnorge/mage/internal/core"
 	"github.com/coopnorge/mage/internal/devtool"
+	"github.com/coopnorge/mage/internal/testhelpers"
 )
 
-var (
-	//go:embed testdata/tools.Dockerfile
-	// TerraformToolsDockerfile the content of tools.Dockerfile
-	TerraformToolsDockerfile string
-)
+// TerraformToolsDockerfile the content of tools.Dockerfile
+//
+//go:embed testdata/tools.Dockerfile
+var TerraformToolsDockerfile string
 
 func TestFindTerraformFolders(t *testing.T) {
 	tests := []struct {
@@ -34,7 +34,7 @@ func TestFindTerraformFolders(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Chdir(tt.workdir)
+			testhelpers.Chdir(t, tt.workdir)
 			got, gotErr := FindTerraformProjects(".")
 			assert.NoError(t, gotErr)
 			assert.ElementsMatch(t, tt.want, got)
@@ -62,7 +62,7 @@ func TestInitUpgradet(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			dir, cleanup, _ := core.MkdirTemp()
 			_ = os.CopyFS(dir, os.DirFS(tt.workdir))
-			t.Chdir(dir)
+			testhelpers.Chdir(t, dir)
 			t.Cleanup(func() {
 				cleanup()
 			})
@@ -100,7 +100,7 @@ func TestLockProviders(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			dir, cleanup, _ := core.MkdirTemp()
 			_ = os.CopyFS(dir, os.DirFS(tt.workdir))
-			t.Chdir(dir)
+			testhelpers.Chdir(t, dir)
 			t.Cleanup(func() {
 				cleanup()
 			})

--- a/internal/testhelpers/chdir.go
+++ b/internal/testhelpers/chdir.go
@@ -1,0 +1,55 @@
+package testhelpers
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// Chdir calls os.Chdir(dir) and uses Cleanup to restore the current
+// working directory to its original value after the test. On Unix, it
+// also sets PWD environment variable for the duration of the test.
+//
+// Because Chdir affects the whole process, it cannot be used
+// in parallel tests or tests with parallel ancestors.
+//
+// This is duplicated from Go 1.24.2's implementation: https://cs.opensource.google/go/go/+/refs/tags/go1.24.4:src/testing/testing.go;l=1345-1385
+// When Go 1.25 is released, we can remove this and use the standard library's implementation instead.
+func Chdir(t *testing.T, dir string) {
+	t.Helper()
+
+	oldwd, err := os.Open(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	// On POSIX platforms, PWD represents “an absolute pathname of the
+	// current working directory.” Since we are changing the working
+	// directory, we should also set or update PWD to reflect that.
+	switch runtime.GOOS {
+	case "windows", "plan9":
+		// Windows and Plan 9 do not use the PWD variable.
+	default:
+		if !filepath.IsAbs(dir) {
+			dir, err = os.Getwd()
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		t.Setenv("PWD", dir)
+	}
+	t.Cleanup(func() {
+		err := oldwd.Chdir()
+		oldwd.Close() //nolint:errcheck // Copy of stdlibs implementation, which ignores the error here.
+		if err != nil {
+			// It's not safe to continue with tests if we can't
+			// get back to the original working directory. Since
+			// we are holding a dirfd, this is highly unlikely.
+			panic("testing.Chdir: " + err.Error())
+		}
+	})
+}


### PR DESCRIPTION
Requiring Go 1.24 will cause every app/library that wants to use this library to also require 1.24. This is fine for go-apps, but libraries still want to stay on 1.23, until 1.25 is released.

The only real requirement we have on 1.24 in this repo, is the `t.Chdir` function, which we can copy the behviour of, until Go 1.25 is released.
