### PR TITLE
chore(package): Upgrade to go 1.25.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coopnorge/mage
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/magefile/mage v1.15.0

--- a/internal/targets/terraform/terraform_test.go
+++ b/internal/targets/terraform/terraform_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 var goModTemplateString = `module dummy
-go 1.24.0
-require github.com/coopnorge/mage v0.4.3
+go 1.25.0
+require github.com/coopnorge/mage v0.7.0
 require github.com/magefile/mage v1.15.0 // indirect
 tool github.com/magefile/mage
 replace github.com/coopnorge/mage => {{ . }}


### PR DESCRIPTION
Updates go to version 1.25.0 and runs `go mod tidy`.

Before:
  `go 1.24.0`

After:
  `go 1.25.0`

More details can be found here:
- This PR seeks to address https://github.com/coopnorge/engineering-issues/issues/451
