### PR TITLE
chore: bump timeout for golangci-lint

### DIFF
--- a/internal/golang/golang.go
+++ b/internal/golang/golang.go
@@ -63,7 +63,7 @@ func Generate(directory string) error {
 // Test automates testing the packages named by the import paths, see also: go
 // test.
 func Test(directory string) error {
-	err := os.MkdirAll(path.Join(core.OutputDir, directory), 0700)
+	err := os.MkdirAll(path.Join(core.OutputDir, directory), 0o700)
 	if err != nil {
 		return err
 	}
@@ -95,7 +95,7 @@ func Lint(directory, golangCILintCfg string) error {
 		return err
 	}
 
-	return DevtoolGolangCILint(nil, "bash", "-c", fmt.Sprintf("cd %s && golangci-lint run --verbose --timeout 5m --config %s ./...", directory, lintCfgPath))
+	return DevtoolGolangCILint(nil, "bash", "-c", fmt.Sprintf("cd %s && golangci-lint run --verbose --timeout 10m --config %s ./...", directory, lintCfgPath))
 }
 
 // LintFix fixes found issues (if it's supported by the linters)
@@ -110,7 +110,7 @@ func LintFix(directory, golangCILintCfg string) error {
 	if err != nil {
 		return err
 	}
-	return DevtoolGolangCILint(nil, "bash", "-c", fmt.Sprintf("cd %s && golangci-lint run --verbose --timeout 5m --fix --config %s ./...", directory, lintCfgPath))
+	return DevtoolGolangCILint(nil, "bash", "-c", fmt.Sprintf("cd %s && golangci-lint run --verbose --timeout 10m --fix --config %s ./...", directory, lintCfgPath))
 }
 
 // DownloadModules downloads Go modules locally


### PR DESCRIPTION
The timeout of 5m is blocking our deployments. The linter runs for ~10 seconds on my macbook for `idp-user-service`, but times out in CI. We should come up with a proper fix, but bumping the timeout should unblock our deployments.

(Example run that fails with 5 minute timeout)
