### PR TITLE
fix: code detection on github push event

### DIFF
--- a/.github/workflows/goapp.yaml
+++ b/.github/workflows/goapp.yaml
@@ -44,7 +44,7 @@ jobs:
     permissions:
       contents: read
     outputs:
-      golang: ${{ steps.go.outputs.golang == 'true' }}
+      golang: ${{ steps.go.outputs.golang == 'true' || github.event_name == 'workflow_dispatch' }}
       terraform: ${{ steps.terraform.outputs.terraform == 'true' && github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
It seems that code detection is working only in PRs right now.

So for example the following steps ran in this PR branch - https://github.com/coopnorge/social-media-aggregator/actions/runs/18527554885
<img width="1259" height="86" alt="Screenshot 2025-10-17 at 3 54 07 PM" src="https://github.com/user-attachments/assets/bd1cc282-d878-4d64-8aac-e7827e7d9bf8" />

But they didn't run when it was merged to `main` - https://github.com/coopnorge/social-media-aggregator/actions/runs/18527922175
<img width="1261" height="92" alt="Screenshot 2025-10-17 at 3 42 05 PM" src="https://github.com/user-attachments/assets/919c85ae-f0fa-4724-855d-63cbb968c6a6" />

After some investigation I think this check that I removed in this PR is the cause of this behavior.

Additionally, I looked up at how code detection worked in https://github.com/coopnorge/helloworld, and it seems to be defined like so - https://github.com/coopnorge/helloworld/blob/main/.github/workflows/cicd.yaml#L17

So I am a bit unsure, if we need to add a similar check like `|| github.event_name == 'workflow_dispatch'` here as well.