### PR TITLE
fix: Let `reusable-goapp.yaml` build OCI images

### DIFF
--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -84,7 +84,7 @@ jobs:
       - name: Install go Tools
         run: go install tool
       - name: Build
-        run: "go tool mage -v go:build"
+        run: "go tool mage -v docker:buildAndPush"
         env:
           OCI_IMAGE_BASE: ${{ inputs.oci-image-base }}
           PUSH_IMAGE: ${{ inputs.push-oci-image }}

--- a/targets/goapp/main.go
+++ b/targets/goapp/main.go
@@ -45,8 +45,6 @@ package goapp
 
 import (
 	"context"
-	"os"
-	"strconv"
 
 	"github.com/coopnorge/mage/internal/core"
 	"github.com/magefile/mage/mg"
@@ -75,11 +73,7 @@ func Generate(ctx context.Context) error {
 //
 // For details see [Go.Build] and [Docker.BuildAndPush].
 func Build(ctx context.Context) error {
-	shouldPush, err := shouldPush()
-	if err != nil {
-		return err
-	}
-	mg.SerialCtxDeps(ctx, Validate, Go.Build, mg.F(Docker.BuildAndPush, shouldPush))
+	mg.SerialCtxDeps(ctx, Validate, Go.Build, Docker.BuildAndPush)
 	return nil
 }
 
@@ -104,16 +98,4 @@ func Fix(ctx context.Context) error {
 // Deletes the [core.OutputDir].
 func Clean(_ context.Context) error {
 	return sh.Rm(core.OutputDir)
-}
-
-func shouldPush() (bool, error) {
-	val, ok := os.LookupEnv(PushEnv)
-	if !ok || val == "" {
-		return false, nil
-	}
-	boolValue, err := strconv.ParseBool(val)
-	if err != nil {
-		return false, err
-	}
-	return boolValue, nil
 }


### PR DESCRIPTION
By allowing `mage docker:buildAndPush` to be called directly (no "shouldPush" argument), `reusable-goapp.yaml` should be able to build the OCI images properly.
