### PR TITLE
fix: reusable-goapp should propagate oci-images output from the correct job

### DIFF
--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -27,7 +27,7 @@ on:
         description: Run mage go related tasks in "docker" (default) or local
     outputs:
       oci-images:
-        value: ${{ jobs.mage.outputs.oci-images }}
+        value: ${{ jobs.goapp.outputs.oci-images }}
         description: OCI image references.
 
 jobs:


### PR DESCRIPTION
This appears to have been a copy-paste error when creating the reusable workflow. In the original `mage.yaml` workflow (https://github.com/coopnorge/mage/blob/main/.github/workflows/mage.yaml), there was only 1 `job`, and it was named `mage`.

The improved `goapp.yaml` workflow has 3 apps: 1 to detect changes, 1 to run the `reusable-goapp.yaml`, and 1 to run the `reusable-terraform.yaml`

The `goapp.yaml` workflow is correctly defining the output as `value: ${{ jobs.goapp.outputs.oci-images }}`, where `jobs.goapp` is the job that runs `reusable-goapp.yaml`.

The `reusable-goapp.yaml` was **incorrectly** defining the output as `value: ${{ jobs.mage.outputs.oci-images }}`, but there is no `mage` job in this workflow, only `goapp`-job.