### PR TITLE
feat: Modify golang targets to give a cleaner separation

### DIFF
--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -83,10 +83,16 @@ jobs:
           cache-dependency-path: "**/go.sum"
       - name: Install go Tools
         run: go install tool
+        # check if the download devtool command exist and then run it.
+      - name: Check if coop mage has download devtool command
+        id: has-downloaddevtools
+        run: echo "outcome=$(go tool mage -l | grep go:downloadDevTools | wc -l)" >> $GITHUB_OUTPUT
+      - name: Download Go Devtools
+        if: ${{ steps.has-downloaddevtools.outputs.outcome == '1' }}
+        run: "go tool mage -v go:downloadDevTools"
       - name: Check if coop mage has separeate build commands
         id: has-multiple-cmds
         run: echo "outcome=$(go tool mage -l | grep go:buildBinaries | wc -l)" >> $GITHUB_OUTPUT
-
         # this block requires coopnorge/mage > v0.10.0
       - name: Download Go modules
         if: ${{ steps.has-multiple-cmds.outputs.outcome == '1' }}
@@ -107,7 +113,7 @@ jobs:
           OCI_IMAGE_BASE: ${{ inputs.oci-image-base }}
           PUSH_IMAGE: ${{ inputs.push-oci-image }}
           GO_RUNTIME: ${{ inputs.go-runtime }}
-       # this block is uses when <= v0.10.0
+        # this block is uses when <= v0.10.0
       - name: Build Go and Docker Images
         if: ${{ steps.has-multiple-cmds.outputs.outcome == '0' }}
         run: "go tool mage -v docker:buildAndPush"

--- a/internal/targets/golang/golang.go
+++ b/internal/targets/golang/golang.go
@@ -1,3 +1,4 @@
+// Package golang contains targets related to golang
 package golang
 
 import (
@@ -5,8 +6,8 @@ import (
 	_ "embed"
 	"fmt"
 
+	"github.com/coopnorge/mage/internal/devtool"
 	"github.com/coopnorge/mage/internal/golang"
-	"github.com/coopnorge/mage/internal/targets/devtool"
 	"github.com/magefile/mage/mg"
 )
 
@@ -22,7 +23,6 @@ var (
 // the intent to generate Go code. Those commands can run any process but the
 // intent is to create or update Go source files
 func Generate(ctx context.Context) error {
-	mg.CtxDeps(ctx, DownloadModules)
 	directories, err := golang.FindGoModules(".")
 	if err != nil {
 		return err
@@ -37,15 +37,13 @@ func Generate(ctx context.Context) error {
 	return nil
 }
 
-func generate(ctx context.Context, workingDirectory string) error {
-	mg.CtxDeps(ctx, mg.F(devtool.Build, "golang", GolangToolsDockerfile))
+func generate(_ context.Context, workingDirectory string) error {
 	return golang.Generate(workingDirectory)
 }
 
 // Test automates testing the packages named by the import paths, see also: go
 // test.
 func Test(ctx context.Context) error {
-	mg.CtxDeps(ctx, DownloadModules)
 	directories, err := golang.FindGoModules(".")
 	if err != nil {
 		return err
@@ -60,14 +58,12 @@ func Test(ctx context.Context) error {
 	return nil
 }
 
-func test(ctx context.Context, workingDirectory string) error {
-	mg.CtxDeps(ctx, mg.F(devtool.Build, "golang", GolangToolsDockerfile))
+func test(_ context.Context, workingDirectory string) error {
 	return golang.Test(workingDirectory)
 }
 
 // Lint runs the linters
 func Lint(ctx context.Context) error {
-	mg.CtxDeps(ctx, DownloadModules)
 	directories, err := golang.FindGoModules(".")
 	if err != nil {
 		return err
@@ -82,14 +78,12 @@ func Lint(ctx context.Context) error {
 	return nil
 }
 
-func lint(ctx context.Context, workingDirectory string) error {
-	mg.CtxDeps(ctx, mg.F(devtool.Build, "golangci-lint", GolangToolsDockerfile))
+func lint(_ context.Context, workingDirectory string) error {
 	return golang.Lint(workingDirectory, golangCILintCfg)
 }
 
 // LintFix fixes found issues (if it's supported by the linters)
 func LintFix(ctx context.Context) error {
-	mg.CtxDeps(ctx, DownloadModules)
 	directories, err := golang.FindGoModules(".")
 	if err != nil {
 		return err
@@ -105,14 +99,12 @@ func LintFix(ctx context.Context) error {
 	return nil
 }
 
-func lintFix(ctx context.Context, workingDirectory string) error {
-	mg.CtxDeps(ctx, mg.F(devtool.Build, "golangci-lint", GolangToolsDockerfile))
+func lintFix(_ context.Context, workingDirectory string) error {
 	return golang.LintFix(workingDirectory, golangCILintCfg)
 }
 
 // DownloadModules downloads Go modules locally
 func DownloadModules(ctx context.Context) error {
-	mg.CtxDeps(ctx, mg.F(devtool.Build, "golang", GolangToolsDockerfile))
 	directories, err := golang.FindGoModules(".")
 	if err != nil {
 		return err
@@ -149,4 +141,9 @@ func Changes(_ context.Context) error {
 	}
 	fmt.Println("false")
 	return nil
+}
+
+// DownloadDevTool ensure a devool is available on a local system
+func DownloadDevTool(_ context.Context, tool string) error {
+	return devtool.Build(tool, GolangToolsDockerfile)
 }

--- a/targets/golib/golang.go
+++ b/targets/golib/golang.go
@@ -25,6 +25,8 @@ func (Go) Generate(ctx context.Context) error {
 //
 // See [Go.Test] and [Go.Lint] for details.
 func (Go) Validate(ctx context.Context) error {
+	mg.CtxDeps(ctx, Go.DownloadDevTools)
+	mg.CtxDeps(ctx, Go.DownloadModules)
 	mg.CtxDeps(ctx, Go.Test, Go.Lint)
 	return nil
 }
@@ -66,5 +68,22 @@ func (Go) LintFix(ctx context.Context) error {
 // the current branch contains changes compared to the main branch.
 func (Go) Changes(ctx context.Context) error {
 	mg.CtxDeps(ctx, golang.Changes)
+	return nil
+}
+
+// DownloadDevTools download all devtools required for running the golang
+// targets
+func (Go) DownloadDevTools(ctx context.Context) error {
+	mg.CtxDeps(
+		ctx,
+		mg.F(golang.DownloadDevTool, "golang"),
+		mg.F(golang.DownloadDevTool, "golangci-lint"),
+	)
+	return nil
+}
+
+// DownloadModules download the go modules
+func (Go) DownloadModules(ctx context.Context) error {
+	mg.CtxDeps(ctx, golang.DownloadModules)
 	return nil
 }


### PR DESCRIPTION
Download of devtools will be a separate target so this can be run as a
separate step in CI. Also cleaning up some unnecessary targets.

Setup was tested in helloworld on with mage versions 'latest', v0.11 and v0.10
https://github.com/coopnorge/helloworld/pull/2893/commits


Signed-off-by: Atze de Vries <atze.wiebe.de.vries@coop.no>
