### PR TITLE
chore: Make concurrency group names unique to pull request event

### DIFF
--- a/.github/workflows/mage.yaml
+++ b/.github/workflows/mage.yaml
@@ -1,5 +1,5 @@
 concurrency:
-  group: mage-${{ github.workflow }}-${{ github.ref }}
+  group: mage-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 on:
   workflow_call:

--- a/.github/workflows/reusable-terraform.yaml
+++ b/.github/workflows/reusable-terraform.yaml
@@ -1,5 +1,5 @@
 concurrency:
-  group: reusable-terraform-${{ github.workflow }}-${{ github.ref }}
+  group: reusable-terraform-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 on:
   workflow_call:


### PR DESCRIPTION
When PRs are merged, I notice that one of the workflow is cancelled because of concurrency issue, see:
- https://github.com/coopnorge/terraform-azure-stack-attach-ad-app/actions/runs/19431412368?pr=68
- https://github.com/coopnorge/terraform-azure-stack-attach-ad-app/actions/runs/19431412067

We want both to run.