### PR TITLE
feat(ci): Indicate whether an image was pushed

### DIFF
--- a/.github/workflows/goapp.yaml
+++ b/.github/workflows/goapp.yaml
@@ -37,6 +37,9 @@ on:
       oci-images:
         value: ${{ jobs.goapp.outputs.oci-images }}
         description: OCI image references.
+      oci-image-pushed:
+        value: ${{ jobs.goapp.outputs.oci-image-pushed }}
+        description: Whether an OCI image was pushed.
 jobs:
   detect-changes:
     name: Detect Changes

--- a/.github/workflows/mage.yaml
+++ b/.github/workflows/mage.yaml
@@ -29,6 +29,9 @@ on:
       oci-images:
         value: ${{ jobs.mage.outputs.oci-images }}
         description: OCI image references.
+      oci-image-pushed:
+        value: ${{ jobs.mage.outputs.oci-image-pushed }}
+        description: Whether an OCI image was pushed.
 jobs:
   mage:
     runs-on: ubuntu-24.04
@@ -38,6 +41,7 @@ jobs:
       packages: read
     outputs:
       oci-images: ${{ steps.oci-images.outputs.images }}
+      oci-image-pushed: ${{ steps.oci-images.outputs.oci-image-pushed }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -109,8 +113,10 @@ jobs:
         run: |
           if [ -f ./var/oci-images.json ]; then
             echo "images=$(cat ./var/oci-images.json)" >> $GITHUB_OUTPUT
+            echo "oci-image-pushed=true" >> $GITHUB_OUTPUT
           else
             echo "images={}" >> $GITHUB_OUTPUT
+            echo "oci-image-pushed=false" >> $GITHUB_OUTPUT
           fi
       - name: Show output
         if: always()

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -29,6 +29,9 @@ on:
       oci-images:
         value: ${{ jobs.goapp.outputs.oci-images }}
         description: OCI image references.
+      oci-image-pushed:
+        value: ${{ jobs.goapp.outputs.oci-image-pushed }}
+        description: Whether an OCI image was pushed.
 
 jobs:
   goapp:
@@ -40,6 +43,7 @@ jobs:
       packages: read
     outputs:
       oci-images: ${{ steps.oci-images.outputs.images }}
+      oci-image-pushed: ${{ steps.oci-images.outputs.oci-image-pushed }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -126,8 +130,10 @@ jobs:
         run: |
           if [ -f ./var/oci-images.json ]; then
             echo "images=$(cat ./var/oci-images.json)" >> $GITHUB_OUTPUT
+            echo "oci-image-pushed=true" >> $GITHUB_OUTPUT
           else
             echo "images={}" >> $GITHUB_OUTPUT
+            echo "oci-image-pushed=false" >> $GITHUB_OUTPUT
           fi
       - name: Show output
         if: always()


### PR DESCRIPTION
Adds an output that indicates whether an image was pushed.

Dependant workflows can use this output to evaluate whether they should
conditionally execute deployment or other downstream actions based on
whether image building occurred.

Changes:
- Add oci-image-pushed output to mage.yaml
- Add oci-image-pushed output to goapp.yaml and reusable-goapp.yaml
- Set output based on presence of var/oci-images.json file