### PR TITLE
chore: Rename job id in catalog-info reusable job

### DIFF
--- a/.github/workflows/reusable-catalog-info.yaml
+++ b/.github/workflows/reusable-catalog-info.yaml
@@ -7,7 +7,7 @@ on:
     secrets: {}
 
 jobs:
-  validate-policy-bot-config:
+  validate-catalog-info:
     name: Catalog info validator
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
`validate-policy-bot-config` -> `validate-catalog-info`
