### PR TITLE
chore: Retract the old vulnerable versions from the Go Module Proxy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,3 +15,5 @@ require (
 )
 
 tool github.com/magefile/mage
+
+retract [v0.1.0, v0.16.3] // Retracted due to critical bug in earlier versions


### PR DESCRIPTION
This will retract every version up to (and including) v0.16.3. It will go into effect once this PR has been merged and a new release is pushed&pulled.

Reference docs: https://go.dev/ref/mod#go-mod-file-retract

Update:

After releasing this in v0.16.5, I ran `get github.com/coopnorge/mage@v0.16.5` to update the module proxy. I then went to https://pkg.go.dev/github.com/coopnorge/mage@v0.16.5 which responded that it could not find that version. I clicked the button `Request “github.com/coopnorge/mage@v0.16.5”`, and now v0.16.5 is known to the package-site as well, and all the previous versions (0.16.3 and earlier) are marked as retracted: https://pkg.go.dev/github.com/coopnorge/mage@v0.16.5?tab=versions