### PR TITLE
feat: use github releases to decide on when to build

### DIFF
--- a/.github/workflows/goapp.yaml
+++ b/.github/workflows/goapp.yaml
@@ -33,6 +33,13 @@ on:
         type: string
         default: ""
         description: A comma separated list of Globs which triggers terraform ci
+      tag-based-diff:
+        type: boolean
+        default: false
+        description: |
+          When set to true use git tags to calucate when certain build steps are required. When
+          set to false, the github event data will be used. This event might get lost when runs are
+          canceled etc.
     outputs:
       oci-images:
         value: ${{ jobs.goapp.outputs.oci-images }}
@@ -72,12 +79,21 @@ jobs:
       - name: List changes
         id: list
         run: go tool mage git:listChanges
-      - name: Check for Go changes
+      - name: Check for Go changes (pr event based)
         id: go
-        run: echo "golang=$(go tool mage go:changes)" >> $GITHUB_OUTPUT
+        run: |
+          if [[ "$TAG_BASED" == "true" ]]  ; then
+            echo "Running with tag based diff"
+            echo "golang=$(go tool mage go:changes)" >> $GITHUB_OUTPUT
+          else
+            echo "Running with pr event based diff"
+            export CHANGED_FILES="$CHANGES"
+            echo "golang=$(go tool mage go:changes)" >> $GITHUB_OUTPUT
+          fi
         env:
           ADDITIONAL_GLOBS_GO: ${{ inputs.additional-globs-go }}
-          CHANGED_FILES: ${{ steps.filter.outputs.changed_files }}
+          CHANGES: ${{ steps.filter.outputs.changed_files }}
+          TAG_BASED: ${{ inputs.tag-based-diff }}
       - name: Check for Terraform changes
         id: terraform
         run: echo "terraform=$(go tool mage terraform:changes)" >> $GITHUB_OUTPUT

--- a/.github/workflows/goapp.yaml
+++ b/.github/workflows/goapp.yaml
@@ -111,7 +111,7 @@ jobs:
     if: ${{  needs.detect-changes.outputs.golang == 'true'  }}
     uses: ./.github/workflows/reusable-goapp.yaml
     permissions:
-      contents: read
+      contents: write
       id-token: write
       packages: read
     secrets: inherit

--- a/.github/workflows/goapp.yaml
+++ b/.github/workflows/goapp.yaml
@@ -51,6 +51,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      packages: read
     outputs:
       golang: ${{ steps.go.outputs.golang == 'true' || github.event_name == 'workflow_dispatch' }}
       terraform: ${{ steps.terraform.outputs.terraform == 'true' && github.event_name == 'pull_request' }}
@@ -94,6 +95,7 @@ jobs:
           ADDITIONAL_GLOBS_GO: ${{ inputs.additional-globs-go }}
           CHANGES: ${{ steps.filter.outputs.changed_files }}
           TAG_BASED: ${{ inputs.tag-based-diff }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Check for Terraform changes
         id: terraform
         run: echo "terraform=$(go tool mage terraform:changes)" >> $GITHUB_OUTPUT

--- a/.github/workflows/goapp.yaml
+++ b/.github/workflows/goapp.yaml
@@ -111,7 +111,7 @@ jobs:
     if: ${{  needs.detect-changes.outputs.golang == 'true'  }}
     uses: ./.github/workflows/reusable-goapp.yaml
     permissions:
-      contents: write
+      contents: read
       id-token: write
       packages: read
     secrets: inherit

--- a/.github/workflows/goapp.yaml
+++ b/.github/workflows/goapp.yaml
@@ -35,7 +35,7 @@ on:
         description: A comma separated list of Globs which triggers terraform ci
       tag-based-diff:
         type: boolean
-        default: false
+        default: true
         description: |
           When set to true use git tags to calucate when certain build steps are required. When
           set to false, the github event data will be used. This event might get lost when runs are
@@ -136,6 +136,7 @@ jobs:
       push-oci-image: ${{ inputs.push-oci-image }}
       workload-identity-provider: ${{ inputs.workload-identity-provider }}
       service-account: ${{ inputs.service-account }}
+      tag-based-diff: ${{ inputs.tag-based-diff }}
 
   terraform:
     name: Terraform

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -1,6 +1,5 @@
 concurrency:
   group: reusable-goapp-${{ github.workflow }}-${{ github.ref }}
-  # we might thing about disabling cancel on the main branch
   cancel-in-progress: true
 on:
   workflow_call:

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -191,7 +191,7 @@ jobs:
         id: generate_token
         if: ${{ github.ref == 'refs/heads/main' && inputs.tag-based-diff }}
         # v1.5.1
-        uses: actions/create-github-app-token@v2.2.1
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # pin@v2.2.1
         with:
           app-id: 172868
           private-key: ${{ secrets.WRITEBACK_APP_PRIVATE_KEY_PEM }}

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -182,6 +182,21 @@ jobs:
           else
             echo "images={}" >> $GITHUB_OUTPUT
           fi
+      - name: Generate token for writeback to pr
+        id: generate_token
+        # v1.5.1
+        uses: actions/create-github-app-token@v2.2.1
+        with:
+          app-id: 172868
+          private-key: ${{ secrets.WRITEBACK_APP_PRIVATE_KEY_PEM }}
+          owner: coopnorge
+
+      - name: Get GitHub App User ID for the writeback to pr bot
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.generate_token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+
       - id: oci-tag-repo
         if: ${{ github.ref == 'refs/heads/main' }}
         name: Tag the repo with oci build tag
@@ -193,10 +208,10 @@ jobs:
           fi
           GIT_TAG="mage/oci/${OCI_TAG}"
           echo "tagging repo with tag ${GIT_TAG}"
-          git config user.email "mage@coop.no"
-          git config user.name "Mage CI OCI tagger"
+          git config user.email "${{ steps.generate_token.outputs.app-slug }}[bot] <${{ steps.get-user-id.outputs.user-id }}+${{ steps.generate_token.outputs.app-slug }}[bot]@users.noreply.github.com>"
+          git config user.name  "${{ steps.generate_token.outputs.app-slug }}[bot] <${{ steps.get-user-id.outputs.user-id }}+${{ steps.generate_token.outputs.app-slug }}[bot]@users.noreply.github.com>"
           git tag -a ${GIT_TAG} main -m "mage oci build ${OCI_TAG}"
-          AUTH_URL="https://${{ secrets.REVIEWBOT_GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git"
+          AUTH_URL="https://${{ steps.generate_token.outputs.token }}@github.com/${GITHUB_REPOSITORY}.git"
           git push ${AUTH_URL} tag ${GIT_TAG}
 
       - name: Show output

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -214,7 +214,7 @@ jobs:
             echo cannot get an OCI TAG, bailing
             exit 0
           fi
-          GIT_TAG="mage_oci-${OCI_TAG}"
+          GIT_TAG="mage/oci/${OCI_TAG}"
           echo "tagging repo with tag ${GIT_TAG}"
           git config user.email "${{ steps.generate_token.outputs.app-slug }}[bot] <${{ steps.get-user-id.outputs.user-id }}+${{ steps.generate_token.outputs.app-slug }}[bot]@users.noreply.github.com>"
           git config user.name  "${{ steps.generate_token.outputs.app-slug }}[bot] <${{ steps.get-user-id.outputs.user-id }}+${{ steps.generate_token.outputs.app-slug }}[bot]@users.noreply.github.com>"

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -223,7 +223,7 @@ jobs:
           name: "Go OCI Release ${{ steps.oci-tag.outputs.tag }}"
           # only used when no releases exists. Initial release might be to long
           # with out limitation
-          initial-commits-since: 2026-03-01T09:09:09Z'
+          initial-commits-since: "2026-03-01T09:09:09Z"
 
       - name: Show output
         if: always()

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -209,7 +209,7 @@ jobs:
         name: Tag the repo with oci build tag
         working-directory: ./set-tag
         run: |
-          OCI_TAG=$(cat ./var/oci-images.json | yq -P | grep tag: | head -1 | yq .tag)
+          OCI_TAG=$(cat ../var/oci-images.json | yq -P | grep tag: | head -1 | yq .tag)
           if [[ -z "$OCI_TAG" ]]; then
             echo cannot get an OCI TAG, bailing
             exit 1
@@ -218,7 +218,7 @@ jobs:
           echo "tagging repo with tag ${GIT_TAG}"
           git config user.email "${{ steps.generate_token.outputs.app-slug }}[bot] <${{ steps.get-user-id.outputs.user-id }}+${{ steps.generate_token.outputs.app-slug }}[bot]@users.noreply.github.com>"
           git config user.name  "${{ steps.generate_token.outputs.app-slug }}[bot] <${{ steps.get-user-id.outputs.user-id }}+${{ steps.generate_token.outputs.app-slug }}[bot]@users.noreply.github.com>"
-          git tag -a ${GIT_TAG} main -m "mage oci build ${OCI_TAG}"
+          git tag -s -a ${GIT_TAG} main -m "mage oci build ${OCI_TAG}"
           AUTH_URL="https://${{ steps.generate_token.outputs.token }}@github.com/${GITHUB_REPOSITORY}.git"
           git push ${AUTH_URL} tag ${GIT_TAG}
 

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -212,15 +212,17 @@ jobs:
           OCI_TAG=$(cat ../var/oci-images.json | yq -P | grep tag: | head -1 | yq .tag)
           if [[ -z "$OCI_TAG" ]]; then
             echo cannot get an OCI TAG, bailing
-            exit 1
+            exit 0
           fi
           GIT_TAG="mage/oci/${OCI_TAG}"
           echo "tagging repo with tag ${GIT_TAG}"
           git config user.email "${{ steps.generate_token.outputs.app-slug }}[bot] <${{ steps.get-user-id.outputs.user-id }}+${{ steps.generate_token.outputs.app-slug }}[bot]@users.noreply.github.com>"
           git config user.name  "${{ steps.generate_token.outputs.app-slug }}[bot] <${{ steps.get-user-id.outputs.user-id }}+${{ steps.generate_token.outputs.app-slug }}[bot]@users.noreply.github.com>"
           git tag -a ${GIT_TAG} main -m "mage oci build ${OCI_TAG}"
+          git tag -a ${OCI_TAG} main -m "mage oci build ${OCI_TAG}"
           AUTH_URL="https://${{ steps.generate_token.outputs.token }}@github.com/${GITHUB_REPOSITORY}.git"
           git push ${AUTH_URL} tag ${GIT_TAG}
+          git push ${AUTH_URL} tag ${OCI_TAG}
 
       - name: Show output
         if: always()

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -193,6 +193,8 @@ jobs:
           fi
           GIT_TAG="mage/oci/${OCI_TAG}"
           echo "tagging repo with tag ${GIT_TAG}"
+          git config user.email "mage@coop.no"
+          git config user.name "Mage CI OCI tagger"
           git tag -a ${GIT_TAG} main -m "mage oci build ${OCI_TAG}"
 
       - name: Show output

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -204,23 +204,14 @@ jobs:
           path: set-tag
           fetch-tags: true
 
-      - id: oci-tag-repo
-        if: ${{ github.ref == 'refs/heads/main' }}
-        name: Tag the repo with oci build tag
-        working-directory: ./set-tag
-        run: |
-          OCI_TAG=$(cat ../var/oci-images.json | yq -P | grep tag: | head -1 | yq .tag)
-          if [[ -z "$OCI_TAG" ]]; then
-            echo cannot get an OCI TAG, bailing
-            exit 0
-          fi
-          GIT_TAG="mage/oci/${OCI_TAG}"
-          echo "tagging repo with tag ${GIT_TAG}"
-          git config user.email "${{ steps.generate_token.outputs.app-slug }}[bot] <${{ steps.get-user-id.outputs.user-id }}+${{ steps.generate_token.outputs.app-slug }}[bot]@users.noreply.github.com>"
-          git config user.name  "${{ steps.generate_token.outputs.app-slug }}[bot] <${{ steps.get-user-id.outputs.user-id }}+${{ steps.generate_token.outputs.app-slug }}[bot]@users.noreply.github.com>"
-          git tag -a ${GIT_TAG} main -m "mage oci build ${OCI_TAG}"
-          AUTH_URL="https://${{ steps.generate_token.outputs.token }}@github.com/${GITHUB_REPOSITORY}.git"
-          git push ${AUTH_URL} tag ${GIT_TAG}
+      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # pin@v6.1.0
+        id: make-release
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+        with:
+          commitish: main
+          config-name: "release-drafter.yml"
+          publish: true
 
       - name: Show output
         if: always()

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -203,6 +203,7 @@ jobs:
         with:
           github_token: ${{ secrets.REVIEWBOT_GITHUB_TOKEN }}
           push_only_tags: true
+          tags: true
 
       - name: Show output
         if: always()

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -221,6 +221,9 @@ jobs:
           version: ${{ steps.oci-tag.outputs.tag }}
           tag: "v${{ steps.oci-tag.outputs.tag }}"
           name: "Go OCI Release ${{ steps.oci-tag.outputs.tag }}"
+          # only used when no releases exists. Initial release might be to long
+          # with out limitation
+          initial-commits-since: 2026-03-01T09:09:09Z'
 
       - name: Show output
         if: always()

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -201,12 +201,12 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' }}
         name: Fetch the oci tag
         run: |
-          OCI_TAG=$(cat ../var/oci-images.json | yq -P | grep tag: | head -1 | yq .tag)
+          OCI_TAG=$(cat var/oci-images.json | yq -P | grep tag: | head -1 | yq .tag)
           if [[ -z "$OCI_TAG" ]]; then
             echo cannot get an OCI TAG, bailing
             exit 1
           fi
-          echo "tag=$(echo $OCI_TAG") >> $GITHUB_OUTPUT
+          echo "tag=$(echo $OCI_TAG)" >> $GITHUB_OUTPUT
 
       - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # pin@v6.1.0
         id: make-release

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -197,21 +197,28 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
 
-      - name: clean checkout
-        uses: actions/checkout@v6
-        with:
-          token: ${{ steps.generate_token.outputs.token }}
-          path: set-tag
-          fetch-tags: true
+      - id: oci-tag
+        if: ${{ github.ref == 'refs/heads/main' }}
+        name: Tag the repo with oci build tag
+        working-directory: ./set-tag
+        run: |
+          OCI_TAG=$(cat ../var/oci-images.json | yq -P | grep tag: | head -1 | yq .tag)
+          if [[ -z "$OCI_TAG" ]]; then
+            echo cannot get an OCI TAG, bailing
+            exit 1
+          fi
+          echo "tag=$(echo $OCI_TAG") >> $GITHUB_OUTPUT
 
       - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # pin@v6.1.0
         id: make-release
+        if: ${{ github.ref == 'refs/heads/main' }}
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
         with:
           commitish: main
           config-name: "release-drafter.yml"
           publish: true
+          version: ${{ steps.oci-tag.outputs.tag }}
 
       - name: Show output
         if: always()

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -199,8 +199,7 @@ jobs:
 
       - id: oci-tag
         if: ${{ github.ref == 'refs/heads/main' }}
-        name: Tag the repo with oci build tag
-        working-directory: ./set-tag
+        name: Fetch the oci tag
         run: |
           OCI_TAG=$(cat ../var/oci-images.json | yq -P | grep tag: | head -1 | yq .tag)
           if [[ -z "$OCI_TAG" ]]; then

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -192,7 +192,7 @@ jobs:
             exit 1
           fi
           GIT_TAG="mage/oci/${OCI_TAG}"
-          echo "tagging repo with tag ${$GIT_TAG}"
+          echo "tagging repo with tag ${GIT_TAG}"
           git tag -a ${GIT_TAG} main -m "mage oci build ${OCI_TAG}"
 
       - name: Show output

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -185,10 +185,6 @@ jobs:
       - id: oci-tag-repo
         if: ${{ github.ref == 'refs/heads/main' }}
         name: Tag the repo with oci build tag
-        env:
-          # TODO: we should update this to a differnt user
-          # or a github app.
-          GH_TOKEN: ${{ secrets.REVIEWBOT_GITHUB_TOKEN }}
         run: |
           OCI_TAG=$(cat ./var/oci-images.json | yq -P | grep tag: | head -1 | yq .tag)
           if [[ -z "$OCI_TAG" ]]; then
@@ -200,7 +196,9 @@ jobs:
           git config user.email "mage@coop.no"
           git config user.name "Mage CI OCI tagger"
           git tag -a ${GIT_TAG} main -m "mage oci build ${OCI_TAG}"
-          git push origin ${GIT_TAG}
+          # $GITHUB_REPOSITORY
+          AUTH_URL="https://${{ secrets.REVIEWBOT_GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git"
+          git push ${AUTH_URL} ${GIT_TAG}
 
       - name: Show output
         if: always()

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -25,9 +25,9 @@ on:
         type: string
         default: "docker"
         description: Run mage go related tasks in "docker" (default) or local
-      publish-release:
+      tag-based-diff:
         type: boolean
-        default: false
+        default: true
         required: false
         description: If true it will create a github release based on the tag of the OCI
     outputs:
@@ -189,7 +189,7 @@ jobs:
 
       - name: Generate token for release
         id: generate_token
-        if: ${{ github.ref == 'refs/heads/main' && inputs.publish-release }}
+        if: ${{ github.ref == 'refs/heads/main' && inputs.tag-based-diff }}
         # v1.5.1
         uses: actions/create-github-app-token@v2.2.1
         with:
@@ -199,7 +199,7 @@ jobs:
 
       - name: Get tag of the build OCI
         id: oci-tag
-        if: ${{ github.ref == 'refs/heads/main' && inputs.publish-release }}
+        if: ${{ github.ref == 'refs/heads/main' && inputs.tag-based-diff }}
         run: |
           OCI_TAG=$(cat var/oci-images.json | yq -P | grep tag: | head -1 | yq .tag)
           if [[ -z "$OCI_TAG" ]]; then
@@ -211,7 +211,7 @@ jobs:
       - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # pin@v6.1.0
         name: Create release
         id: make-release
-        if: ${{ github.ref == 'refs/heads/main' && inputs.publish-release }}
+        if: ${{ github.ref == 'refs/heads/main' && inputs.tag-based-diff }}
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
         with:

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -1,5 +1,6 @@
 concurrency:
   group: reusable-goapp-${{ github.workflow }}-${{ github.ref }}
+  # we might thing about disabling cancel on the main branch
   cancel-in-progress: true
 on:
   workflow_call:
@@ -181,6 +182,19 @@ jobs:
           else
             echo "images={}" >> $GITHUB_OUTPUT
           fi
+      - id: oci-tag-repo
+        if: ${{ github.ref == 'refs/heads/main' }}
+        name: Tag the repo with oci build tag
+        run: |
+          OCI_TAG=$(cat ./var/oci-images.json | yq -P | grep tag: | head -1 | yq .tag)
+          if [[ -z "$OCI_TAG" ]]; then
+            echo cannot get an OCI TAG, bailing
+            exit 1
+          fi
+          GIT_TAG="mage/oci/${OCI_TAG}"
+          echo "tagging repo with tag ${$GIT_TAG}"
+          git tag -a ${GIT_TAG} main -m "mage oci build ${OCI_TAG}"
+
       - name: Show output
         if: always()
         run: tree var/

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -208,7 +208,7 @@ jobs:
           fi
           echo "tag=$(echo $OCI_TAG)" >> $GITHUB_OUTPUT
 
-      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # pin@v6.1.0
+      - uses: release-drafter/release-drafter@5de93583980a40bd78603b6dfdcda5b4df377b32 # pin@v7.2.0
         name: Create release
         id: make-release
         if: ${{ github.ref == 'refs/heads/main' && inputs.tag-based-diff }}

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -214,7 +214,7 @@ jobs:
             echo cannot get an OCI TAG, bailing
             exit 0
           fi
-          GIT_TAG="mage/oci/${OCI_TAG}"
+          GIT_TAG="mage_oci-${OCI_TAG}"
           echo "tagging repo with tag ${GIT_TAG}"
           git config user.email "${{ steps.generate_token.outputs.app-slug }}[bot] <${{ steps.get-user-id.outputs.user-id }}+${{ steps.generate_token.outputs.app-slug }}[bot]@users.noreply.github.com>"
           git config user.name  "${{ steps.generate_token.outputs.app-slug }}[bot] <${{ steps.get-user-id.outputs.user-id }}+${{ steps.generate_token.outputs.app-slug }}[bot]@users.noreply.github.com>"

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -101,7 +101,7 @@ jobs:
       - go-test
     runs-on: ubuntu-24.04
     permissions:
-      contents: read
+      contents: write
       id-token: write
       packages: read
     outputs:

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -101,7 +101,7 @@ jobs:
       - go-test
     runs-on: ubuntu-24.04
     permissions:
-      contents: write
+      contents: read
       id-token: write
       packages: read
     outputs:
@@ -185,6 +185,10 @@ jobs:
       - id: oci-tag-repo
         if: ${{ github.ref == 'refs/heads/main' }}
         name: Tag the repo with oci build tag
+        env:
+          # TODO: we should update this to a differnt user
+          # or a github app.
+          GH_TOKEN: ${{ secrets.REVIEWBOT_GITHUB_TOKEN }}
         run: |
           OCI_TAG=$(cat ./var/oci-images.json | yq -P | grep tag: | head -1 | yq .tag)
           if [[ -z "$OCI_TAG" ]]; then

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -218,7 +218,7 @@ jobs:
           echo "tagging repo with tag ${GIT_TAG}"
           git config user.email "${{ steps.generate_token.outputs.app-slug }}[bot] <${{ steps.get-user-id.outputs.user-id }}+${{ steps.generate_token.outputs.app-slug }}[bot]@users.noreply.github.com>"
           git config user.name  "${{ steps.generate_token.outputs.app-slug }}[bot] <${{ steps.get-user-id.outputs.user-id }}+${{ steps.generate_token.outputs.app-slug }}[bot]@users.noreply.github.com>"
-          git tag -s -a ${GIT_TAG} main -m "mage oci build ${OCI_TAG}"
+          git tag -a ${GIT_TAG} main -m "mage oci build ${OCI_TAG}"
           AUTH_URL="https://${{ steps.generate_token.outputs.token }}@github.com/${GITHUB_REPOSITORY}.git"
           git push ${AUTH_URL} tag ${GIT_TAG}
 

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -219,6 +219,8 @@ jobs:
           config-name: "release-drafter.yml"
           publish: true
           version: ${{ steps.oci-tag.outputs.tag }}
+          tag: "v${{ steps.oci-tag.outputs.tag }}"
+          name: "Go OCI Release ${{ steps.oci-tag.outputs.tag }}"
 
       - name: Show output
         if: always()

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -201,7 +201,7 @@ jobs:
         id: oci-tag
         if: ${{ github.ref == 'refs/heads/main' && inputs.tag-based-diff }}
         run: |
-          OCI_TAG=$(cat var/oci-images.json | yq -P | grep tag: | head -1 | yq .tag)
+          OCI_TAG=$(cat var/oci-images.json | yq -P | grep "tag:" | head -1 | yq '.tag')
           if [[ -z "$OCI_TAG" ]]; then
             echo cannot get an OCI TAG, bailing
             exit 1

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -219,10 +219,8 @@ jobs:
           git config user.email "${{ steps.generate_token.outputs.app-slug }}[bot] <${{ steps.get-user-id.outputs.user-id }}+${{ steps.generate_token.outputs.app-slug }}[bot]@users.noreply.github.com>"
           git config user.name  "${{ steps.generate_token.outputs.app-slug }}[bot] <${{ steps.get-user-id.outputs.user-id }}+${{ steps.generate_token.outputs.app-slug }}[bot]@users.noreply.github.com>"
           git tag -a ${GIT_TAG} main -m "mage oci build ${OCI_TAG}"
-          git tag -a ${OCI_TAG} main -m "mage oci build ${OCI_TAG}"
           AUTH_URL="https://${{ steps.generate_token.outputs.token }}@github.com/${GITHUB_REPOSITORY}.git"
           git push ${AUTH_URL} tag ${GIT_TAG}
-          git push ${AUTH_URL} tag ${OCI_TAG}
 
       - name: Show output
         if: always()

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -25,6 +25,11 @@ on:
         type: string
         default: "docker"
         description: Run mage go related tasks in "docker" (default) or local
+      publish-release:
+        type: boolean
+        default: false
+        required: false
+        description: If true it will create a github release based on the tag of the OCI
     outputs:
       oci-images:
         value: ${{ jobs.go-build.outputs.oci-images }}
@@ -181,8 +186,10 @@ jobs:
           else
             echo "images={}" >> $GITHUB_OUTPUT
           fi
-      - name: Generate token for writeback to pr
+
+      - name: Generate token for release
         id: generate_token
+        if: ${{ github.ref == 'refs/heads/main' && inputs.publish-release }}
         # v1.5.1
         uses: actions/create-github-app-token@v2.2.1
         with:
@@ -190,15 +197,9 @@ jobs:
           private-key: ${{ secrets.WRITEBACK_APP_PRIVATE_KEY_PEM }}
           owner: coopnorge
 
-      - name: Get GitHub App User ID for the writeback to pr bot
-        id: get-user-id
-        run: echo "user-id=$(gh api "/users/${{ steps.generate_token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
-
-      - id: oci-tag
-        if: ${{ github.ref == 'refs/heads/main' }}
-        name: Fetch the oci tag
+      - name: Get tag of the build OCI
+        id: oci-tag
+        if: ${{ github.ref == 'refs/heads/main' && inputs.publish-release }}
         run: |
           OCI_TAG=$(cat var/oci-images.json | yq -P | grep tag: | head -1 | yq .tag)
           if [[ -z "$OCI_TAG" ]]; then
@@ -208,8 +209,9 @@ jobs:
           echo "tag=$(echo $OCI_TAG)" >> $GITHUB_OUTPUT
 
       - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # pin@v6.1.0
+        name: Create release
         id: make-release
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' && inputs.publish-release }}
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
         with:

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -196,14 +196,8 @@ jobs:
           git config user.email "mage@coop.no"
           git config user.name "Mage CI OCI tagger"
           git tag -a ${GIT_TAG} main -m "mage oci build ${OCI_TAG}"
-      # using this action now, should move this into mage
-      - id: push-tag
-        name: push tag
-        uses: ad-m/github-push-action@77c5b412c50b723d2a4fbc6d71fb5723bcd439aa
-        with:
-          github_token: ${{ secrets.REVIEWBOT_GITHUB_TOKEN }}
-          push_only_tags: true
-          tags: true
+          AUTH_URL="https://${{ secrets.REVIEWBOT_GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git"
+          git push ${AUTH_URL} tag ${GIT_TAG}
 
       - name: Show output
         if: always()

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -197,9 +197,17 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
 
+      - name: clean checkout
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
+          path: set-tag
+          fetch-tags: true
+
       - id: oci-tag-repo
         if: ${{ github.ref == 'refs/heads/main' }}
         name: Tag the repo with oci build tag
+        working-directory: ./set-tag
         run: |
           OCI_TAG=$(cat ./var/oci-images.json | yq -P | grep tag: | head -1 | yq .tag)
           if [[ -z "$OCI_TAG" ]]; then

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -196,6 +196,7 @@ jobs:
           git config user.email "mage@coop.no"
           git config user.name "Mage CI OCI tagger"
           git tag -a ${GIT_TAG} main -m "mage oci build ${OCI_TAG}"
+          git push origin ${GIT_TAG}
 
       - name: Show output
         if: always()

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -196,9 +196,13 @@ jobs:
           git config user.email "mage@coop.no"
           git config user.name "Mage CI OCI tagger"
           git tag -a ${GIT_TAG} main -m "mage oci build ${OCI_TAG}"
-          # $GITHUB_REPOSITORY
-          AUTH_URL="https://${{ secrets.REVIEWBOT_GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git"
-          git push ${AUTH_URL} ${GIT_TAG}
+      # using this action now, should move this into mage
+      - id: push-tag
+        name: push tag
+        uses: ad-m/github-push-action@77c5b412c50b723d2a4fbc6d71fb5723bcd439aa
+        with:
+          github_token: ${{ secrets.REVIEWBOT_GITHUB_TOKEN }}
+          push_only_tags: true
 
       - name: Show output
         if: always()

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -219,7 +219,7 @@ jobs:
           config-name: "release-drafter.yml"
           publish: true
           version: ${{ steps.oci-tag.outputs.tag }}
-          tag: "v${{ steps.oci-tag.outputs.tag }}"
+          tag: ${{ steps.oci-tag.outputs.tag }}
           name: "Go OCI Release ${{ steps.oci-tag.outputs.tag }}"
           # only used when no releases exists. Initial release might be to long
           # with out limitation

--- a/docs/index.md
+++ b/docs/index.md
@@ -175,96 +175,59 @@ mage:
 
 ## Updating OCI tags after build
 
-You can use renovate to create pr's that update your infrastrucutre. You need a
-renovate config. Save this in `.github/renovate.json5`
+You can use renovate to create pull request that update your infrastructure. You
+need a renovate config. Save this in `.github/renovate.json5`
 
 ```json5
 {
-  "baseBranchPatterns": [
-    "main"
-  ],
-  "rebaseWhen": "behind-base-branch",
-  "labels": [
-    "dependencies",
-    "renovate",
-    "{{depName}}"
-  ],
-  "automergeStrategy": "squash",
-  "enabledManagers": [
-    "helmv3",
-    "helm-values"
-  ],
-  "packageRules": [
+  baseBranchPatterns: ["main"],
+  rebaseWhen: "behind-base-branch",
+  labels: ["dependencies", "renovate", "{{depName}}"],
+  automergeStrategy: "squash",
+  enabledManagers: ["helmv3", "helm-values"],
+  packageRules: [
     {
-      "matchDatasources": [
-        "helm"
-      ],
-      "automerge": true
+      matchDatasources: ["helm"],
+      automerge: true,
     },
     {
-      "branchPrefix": "helm/dev/",
-      "matchManagers": [
-        "helm-values"
-      ],
-      "matchDatasources": [
-        "docker"
-      ],
-      "automerge": true,
-      "matchFileNames": [
-        "/(^|/)values-dev.yaml$/"
-      ],
-      "addLabels": [
-        "development"
-      ],
-      "prHourlyLimit": 0
+      branchPrefix: "helm/dev/",
+      matchManagers: ["helm-values"],
+      matchDatasources: ["docker"],
+      automerge: true,
+      matchFileNames: ["/(^|/)values-dev.yaml$/"],
+      addLabels: ["development"],
+      prHourlyLimit: 0,
     },
     {
-      "branchPrefix": "helm/staging/",
-      "matchManagers": [
-        "helm-values"
-      ],
-      "matchDatasources": [
-        "docker"
-      ],
-      "automerge": true,
-      "matchFileNames": [
-        "/(^|/)values-staging.yaml$/"
-      ],
-      "addLabels": [
-        "staging"
-      ],
-      "prHourlyLimit": 0
+      branchPrefix: "helm/staging/",
+      matchManagers: ["helm-values"],
+      matchDatasources: ["docker"],
+      automerge: true,
+      matchFileNames: ["/(^|/)values-staging.yaml$/"],
+      addLabels: ["staging"],
+      prHourlyLimit: 0,
     },
     {
-      "branchPrefix": "helm/production/",
-      "matchManagers": [
-        "helm-values"
-      ],
-      "matchDatasources": [
-        "docker"
-      ],
-      "automerge": true,
-      "matchFileNames": [
-        "/(^|/)values-production.yaml$/"
-      ],
-      "addLabels": [
-        "production"
-      ],
-      "prHourlyLimit": 0
-    }
+      branchPrefix: "helm/production/",
+      matchManagers: ["helm-values"],
+      matchDatasources: ["docker"],
+      automerge: true,
+      matchFileNames: ["/(^|/)values-production.yaml$/"],
+      addLabels: ["production"],
+      prHourlyLimit: 0,
+    },
   ],
   "helm-values": {
-    "managerFilePatterns": [
-      "/(^|/)values(-\\w+)?\\.ya?ml$/"
-    ]
-  }
+    managerFilePatterns: ["/(^|/)values(-\\w+)?\\.ya?ml$/"],
+  },
 }
 ```
 
 > This renovate config is also valid for updating your helm chart dependencies.
 
-For now you also need a github action job for running renovate. In the future
-this might be handeled by a actual renovate server.
+For now you also need a GitHub action job for running renovate. In the future
+this might be done by a actual renovate server.
 
 Save this to `.github/workflows/renovate.yaml`
 
@@ -313,7 +276,8 @@ jobs:
         id: gcp-auth
         uses: google-github-actions/auth@v3
         with:
-          workload-identity-provider: ${{ vars.PALLET_WORKLOAD_IDENTITY_PROVIDER }}
+          workload-identity-provider:
+            ${{ vars.PALLET_WORKLOAD_IDENTITY_PROVIDER }}
           # or use hardcoded like: workload_identity_provider: projects/889992792607/locations/global/workloadIdentityPools/github-actions/providers/github-actions-provider
           service-account: ${{ vars.PALLET_SERVICE_ACCOUNT }}
           # or use hardcoded like: service_account: gh-ap-helloworld@helloworld-shared-0918.iam.gserviceaccount.com
@@ -325,10 +289,14 @@ jobs:
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_ONBOARDING: "false"
           RENOVATE_USERNAME: "coopnorge-renovate[bot]"
-          RENOVATE_GIT_AUTHOR: "coopnorge-renovate <121964725+coopnorge-renovate[bot]@users.noreply.github.com>"
+          RENOVATE_GIT_AUTHOR:
+            "coopnorge-renovate
+            <121964725+coopnorge-renovate[bot]@users.noreply.github.com>"
           RENOVATE_PLATFORM_COMMIT: "true"
           RENOVATE_FORCE: "true"
-          RENOVATE_HOST_RULES: '[{"matchHost":"europe-docker.pkg.dev","token":"${{ steps.gcp-auth.outputs.access_token }}"}]'
+          RENOVATE_HOST_RULES:
+            '[{"matchHost":"europe-docker.pkg.dev","token":"${{
+            steps.gcp-auth.outputs.access_token }}"}]'
           RENOVATE_PR_BODY_TEMPLATE: "{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}{{{configDescription}}}{{{controls}}}{{{footer}}}"
           LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
         with:

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,8 +64,8 @@ other relevant targets for the tech stack.
 package main
 
 import (
-    //mage:import
-    _ "github.com/coopnorge/mage/targets/goapp"
+  //mage:import
+  _ "github.com/coopnorge/mage/targets/goapp"
 )
 ```
 
@@ -91,8 +91,8 @@ import (
 package main
 
 import (
-    //mage:import
-    _ "github.com/coopnorge/mage/targets/golib"
+  //mage:import
+  _ "github.com/coopnorge/mage/targets/golib"
 )
 ```
 
@@ -180,47 +180,84 @@ need a renovate config. Save this in `.github/renovate.json5`
 
 ```json5
 {
-  baseBranchPatterns: ["main"],
-  rebaseWhen: "behind-base-branch",
-  labels: ["dependencies", "renovate", "{{depName}}"],
-  automergeStrategy: "squash",
-  enabledManagers: ["helmv3", "helm-values"],
-  packageRules: [
+  "extends": ["github>coopnorge/github-workflow-renovate"],
+  "packageRules": [
     {
-      matchDatasources: ["helm"],
-      automerge: true,
+      "matchDatasources": [
+        "helm"
+      ],
+      "automerge": true,
+      "rebaseWhen": "behind-base-branch",
+      "minimumReleaseAge": "0 days",
     },
     {
-      branchPrefix: "helm/dev/",
-      matchManagers: ["helm-values"],
-      matchDatasources: ["docker"],
-      automerge: true,
-      matchFileNames: ["/(^|/)values-dev.yaml$/"],
-      addLabels: ["development"],
-      prHourlyLimit: 0,
+      "matchManagers": [
+        "helm-values"
+      ],
+      "matchDatasources": [
+        "docker"
+      ],
+      "rebaseWhen": "behind-base-branch",
+      "prHourlyLimit": 0,
+      "minimumReleaseAge": "0 days",
     },
     {
-      branchPrefix: "helm/staging/",
-      matchManagers: ["helm-values"],
-      matchDatasources: ["docker"],
-      automerge: true,
-      matchFileNames: ["/(^|/)values-staging.yaml$/"],
-      addLabels: ["staging"],
-      prHourlyLimit: 0,
+      "branchPrefix": "helm/dev/",
+      "matchManagers": [
+        "helm-values"
+      ],
+      "matchDatasources": [
+        "docker"
+      ],
+      "automerge": true,
+      "matchFileNames": [
+        "/(^|/)values-dev.yaml$/"
+      ],
+      "addLabels": [
+        "development"
+      ],
+      "prHourlyLimit": 0
     },
     {
-      branchPrefix: "helm/production/",
-      matchManagers: ["helm-values"],
-      matchDatasources: ["docker"],
-      automerge: true,
-      matchFileNames: ["/(^|/)values-production.yaml$/"],
-      addLabels: ["production"],
-      prHourlyLimit: 0,
+      "branchPrefix": "helm/staging/",
+      "matchManagers": [
+        "helm-values"
+      ],
+      "matchDatasources": [
+        "docker"
+      ],
+      "automerge": true,
+      "matchFileNames": [
+        "/(^|/)values-staging.yaml$/"
+      ],
+      "addLabels": [
+        "staging"
+      ],
+      "prHourlyLimit": 0
     },
+    {
+      "branchPrefix": "helm/production/",
+      "matchManagers": [
+        "helm-values"
+      ],
+      "matchDatasources": [
+        "docker"
+      ],
+      "automerge": true,
+      "matchFileNames": [
+        "/(^|/)values-production.yaml$/"
+      ],
+      "addLabels": [
+        "production"
+      ],
+      "prHourlyLimit": 0
+    }
   ],
   "helm-values": {
-    managerFilePatterns: ["/(^|/)values(-\\w+)?\\.ya?ml$/"],
-  },
+    "managerFilePatterns": [
+      "/(^|/)values(-\\w+)?\\.ya?ml$/"
+    ]
+  }
 }
 ```
 
@@ -231,28 +268,25 @@ this might be done by a actual renovate server.
 
 Save this to `.github/workflows/renovate.yaml`
 
+> make sure update the values to your own repo settings
+
 ```yaml
+
 on:
   push:
     tags:
       - "v*"
-  workflow_call:
-    inputs:
-      logLevel:
-        description: "Override default log level"
-        required: false
-        default: "info"
-        type: string
-    secrets: {}
   workflow_dispatch:
     inputs:
-      logLevel:
+      log-level:
         description: "Override default log level"
         required: false
-        default: "info"
+        default: "debug"
         type: string
   schedule:
+    # At 07:30 AM and 12:30 PM, every day
     - cron: "30 7,12 * * *"
+
 jobs:
   renovate:
     permissions:
@@ -260,48 +294,13 @@ jobs:
       pull-requests: write
       id-token: write
       issues: write
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Get token
-        id: get_token
-        uses: actions/create-github-app-token@v2.2.1
-        with:
-          app-id: 635546
-          private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY_PEM }}
-          owner: ${{github.repository_owner }}
-          repositories: helloworld
-      - name: Autenticate with GCP
-        id: gcp-auth
-        uses: google-github-actions/auth@v3
-        with:
-          workload-identity-provider:
-            ${{ vars.PALLET_WORKLOAD_IDENTITY_PROVIDER }}
-          # or use hardcoded like: workload_identity_provider: projects/889992792607/locations/global/workloadIdentityPools/github-actions/providers/github-actions-provider
-          service-account: ${{ vars.PALLET_SERVICE_ACCOUNT }}
-          # or use hardcoded like: service_account: gh-ap-helloworld@helloworld-shared-0918.iam.gserviceaccount.com
-          token_format: access_token
-          create_credentials_file: true
-      - name: Run Renovate
-        uses: renovatebot/github-action@822441559e94f98b67b82d97ab89fe3003b0a247 # v44.2.0
-        env:
-          RENOVATE_REPOSITORIES: ${{ github.repository }}
-          RENOVATE_ONBOARDING: "false"
-          RENOVATE_USERNAME: "coopnorge-renovate[bot]"
-          RENOVATE_GIT_AUTHOR:
-            "coopnorge-renovate
-            <121964725+coopnorge-renovate[bot]@users.noreply.github.com>"
-          RENOVATE_PLATFORM_COMMIT: "true"
-          RENOVATE_FORCE: "true"
-          RENOVATE_HOST_RULES:
-            '[{"matchHost":"europe-docker.pkg.dev","token":"${{
-            steps.gcp-auth.outputs.access_token }}"}]'
-          RENOVATE_PR_BODY_TEMPLATE: "{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}{{{configDescription}}}{{{controls}}}{{{footer}}}"
-          LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
-        with:
-          configurationFile: .github/renovate.json
-          token: ${{ steps.get_token.outputs.token }}
+    uses: coopnorge/github-workflow-renovate/.github/workflows/renovate.yaml@v0
+    secrets: inherit
+    with:
+      config-file: ".github/renovate.json5"
+      log-level: ${{ inputs.log-level }}
+      gcp-workload-identity-provider: projects/889992792607/locations/global/workloadIdentityPools/github-actions/providers/github-actions-provider
+      gcp-service-account: gh-ap-helloworld@helloworld-shared-0918.iam.gserviceaccount.com
 ```
 
 ## Troubleshooting

--- a/docs/index.md
+++ b/docs/index.md
@@ -176,65 +176,18 @@ mage:
 ## Updating OCI tags after build
 
 You can use renovate to create pull request that update your infrastructure. You
-need a renovate config. Save this in `.github/renovate.json5`
+can find docs [here for how to configure renovate][renovate]. Below is an
+example on how it is used in [helloworld][helloworld]. Note that we need to
+trigger the renovate workflow on push of tags as well.
 
 ```json5
 {
   extends: ["github>coopnorge/github-workflow-renovate"],
-  packageRules: [
-    {
-      matchDatasources: ["helm"],
-      automerge: true,
-      rebaseWhen: "behind-base-branch",
-      minimumReleaseAge: "0 days",
-    },
-    {
-      matchManagers: ["helm-values"],
-      matchDatasources: ["docker"],
-      rebaseWhen: "behind-base-branch",
-      prHourlyLimit: 0,
-      minimumReleaseAge: "0 days",
-    },
-    {
-      branchPrefix: "helm/dev/",
-      matchManagers: ["helm-values"],
-      matchDatasources: ["docker"],
-      automerge: true,
-      matchFileNames: ["/(^|/)values-dev.yaml$/"],
-      addLabels: ["development"],
-      prHourlyLimit: 0,
-    },
-    {
-      branchPrefix: "helm/staging/",
-      matchManagers: ["helm-values"],
-      matchDatasources: ["docker"],
-      automerge: true,
-      matchFileNames: ["/(^|/)values-staging.yaml$/"],
-      addLabels: ["staging"],
-      prHourlyLimit: 0,
-    },
-    {
-      branchPrefix: "helm/production/",
-      matchManagers: ["helm-values"],
-      matchDatasources: ["docker"],
-      automerge: true,
-      matchFileNames: ["/(^|/)values-production.yaml$/"],
-      addLabels: ["production"],
-      prHourlyLimit: 0,
-    },
-  ],
-  "helm-values": {
-    managerFilePatterns: ["/(^|/)values(-\\w+)?\\.ya?ml$/"],
-  },
 }
 ```
 
-> This renovate config is also valid for updating your helm chart dependencies.
-
-For now you also need a GitHub action job for running renovate. In the future
-this might be done by a actual renovate server.
-
-Save this to `.github/workflows/renovate.yaml`
+For now you also need a GitHub action job for running renovate. Save this to
+`.github/workflows/renovate.yaml`
 
 > make sure update the values to your own repo settings
 
@@ -295,3 +248,6 @@ Solution:
 ```shell
   DOCKER_BUILDKIT=1 docker buildx create --use --driver docker-container
 ```
+
+[renovate]: https://inventory.internal.coop/docs/default/component/renovate/
+[helloworld]: https://github.com/coopnorge/helloworld

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,8 +64,8 @@ other relevant targets for the tech stack.
 package main
 
 import (
- //mage:import
- _ "github.com/coopnorge/mage/targets/goapp"
+    //mage:import
+    _ "github.com/coopnorge/mage/targets/goapp"
 )
 ```
 
@@ -91,8 +91,8 @@ import (
 package main
 
 import (
- //mage:import
- _ "github.com/coopnorge/mage/targets/golib"
+    //mage:import
+    _ "github.com/coopnorge/mage/targets/golib"
 )
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -223,6 +223,60 @@ jobs:
       gcp-service-account: gh-ap-helloworld@helloworld-shared-0918.iam.gserviceaccount.com
 ```
 
+### Auto merging OCI updates to infrastructure
+
+You can add rules to your `.policy.yml` to automatically merge pull requests
+that update your OCI tags in your infrastructure. Here are example rules from
+`helloworld`
+
+```yaml
+- name: Dev and staging image update update
+  requires:
+    count: 0
+    teams:
+      - "coopnorge/engineering"
+  options:
+    invalidate_on_push: true
+    request_review:
+      enabled: true
+      mode: all-users
+    methods:
+      github_review: true
+      comments: []
+  if:
+    only_has_contributors_in:
+      users:
+        - "renovate-coop-norge[bot]"
+    only_changed_files:
+      paths:
+        - "^infrastructure/kubernetes/helm/helloworld/values-dev.yaml*"
+        - "^infrastructure/kubernetes/helm/helloworld/values-staging.yaml*"
+    has_valid_signatures_by_keys:
+      key_ids: ["B5690EEEBB952194"]
+- name: Prod image update update
+  requires:
+    count: 1
+    teams:
+      - "coopnorge/engineering"
+  options:
+    invalidate_on_push: true
+    request_review:
+      enabled: true
+      mode: all-users
+    methods:
+      github_review: true
+      comments: []
+  if:
+    only_has_contributors_in:
+      users:
+        - "renovate-coop-norge[bot]"
+    only_changed_files:
+      paths:
+        - "^infrastructure/kubernetes/helm/helloworld/values-production.yaml*"
+    has_valid_signatures_by_keys:
+      key_ids: ["B5690EEEBB952194"]
+```
+
 ## Troubleshooting
 
 - During build the command `git status --porcelain` returns the error message

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,8 +64,8 @@ other relevant targets for the tech stack.
 package main
 
 import (
-    //mage:import
-    _ "github.com/coopnorge/mage/targets/goapp"
+	//mage:import
+	_ "github.com/coopnorge/mage/targets/goapp"
 )
 ```
 
@@ -91,8 +91,8 @@ import (
 package main
 
 import (
-    //mage:import
-    _ "github.com/coopnorge/mage/targets/golib"
+	//mage:import
+	_ "github.com/coopnorge/mage/targets/golib"
 )
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,8 +64,8 @@ other relevant targets for the tech stack.
 package main
 
 import (
-	//mage:import
-	_ "github.com/coopnorge/mage/targets/goapp"
+ //mage:import
+ _ "github.com/coopnorge/mage/targets/goapp"
 )
 ```
 
@@ -91,8 +91,8 @@ import (
 package main
 
 import (
-	//mage:import
-	_ "github.com/coopnorge/mage/targets/golib"
+ //mage:import
+ _ "github.com/coopnorge/mage/targets/golib"
 )
 ```
 
@@ -148,6 +148,7 @@ go-app:
     push-oci-image: ${{ github.ref == 'refs/heads/main' }}
     workload-identity-provider: ${{ vars.PALLET_WORKLOAD_IDENTITY_PROVIDER }}
     service-account: ${{ vars.PALLET_SERVICE_ACCOUNT }}
+    tag-based-diff: true
 ```
 
 If you did not create a system through inventory you have to hard-code the
@@ -170,6 +171,169 @@ mage:
     id-token: write
     packages: read
   secrets: inherit
+```
+
+## Updating OCI tags after build
+
+You can use renovate to create pr's that update your infrastrucutre. You need a
+renovate config. Save this in `.github/renovate.json5`
+
+```json5
+{
+  "baseBranchPatterns": [
+    "main"
+  ],
+  "rebaseWhen": "behind-base-branch",
+  "labels": [
+    "dependencies",
+    "renovate",
+    "{{depName}}"
+  ],
+  "automergeStrategy": "squash",
+  "enabledManagers": [
+    "helmv3",
+    "helm-values"
+  ],
+  "packageRules": [
+    {
+      "matchDatasources": [
+        "helm"
+      ],
+      "automerge": true
+    },
+    {
+      "branchPrefix": "helm/dev/",
+      "matchManagers": [
+        "helm-values"
+      ],
+      "matchDatasources": [
+        "docker"
+      ],
+      "automerge": true,
+      "matchFileNames": [
+        "/(^|/)values-dev.yaml$/"
+      ],
+      "addLabels": [
+        "development"
+      ],
+      "prHourlyLimit": 0
+    },
+    {
+      "branchPrefix": "helm/staging/",
+      "matchManagers": [
+        "helm-values"
+      ],
+      "matchDatasources": [
+        "docker"
+      ],
+      "automerge": true,
+      "matchFileNames": [
+        "/(^|/)values-staging.yaml$/"
+      ],
+      "addLabels": [
+        "staging"
+      ],
+      "prHourlyLimit": 0
+    },
+    {
+      "branchPrefix": "helm/production/",
+      "matchManagers": [
+        "helm-values"
+      ],
+      "matchDatasources": [
+        "docker"
+      ],
+      "automerge": true,
+      "matchFileNames": [
+        "/(^|/)values-production.yaml$/"
+      ],
+      "addLabels": [
+        "production"
+      ],
+      "prHourlyLimit": 0
+    }
+  ],
+  "helm-values": {
+    "managerFilePatterns": [
+      "/(^|/)values(-\\w+)?\\.ya?ml$/"
+    ]
+  }
+}
+```
+
+> This renovate config is also valid for updating your helm chart dependencies.
+
+For now you also need a github action job for running renovate. In the future
+this might be handeled by a actual renovate server.
+
+Save this to `.github/workflows/renovate.yaml`
+
+```yaml
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_call:
+    inputs:
+      logLevel:
+        description: "Override default log level"
+        required: false
+        default: "info"
+        type: string
+    secrets: {}
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: "Override default log level"
+        required: false
+        default: "info"
+        type: string
+  schedule:
+    - cron: "30 7,12 * * *"
+jobs:
+  renovate:
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+      issues: write
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Get token
+        id: get_token
+        uses: actions/create-github-app-token@v2.2.1
+        with:
+          app-id: 635546
+          private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY_PEM }}
+          owner: ${{github.repository_owner }}
+          repositories: helloworld
+      - name: Autenticate with GCP
+        id: gcp-auth
+        uses: google-github-actions/auth@v3
+        with:
+          workload-identity-provider: ${{ vars.PALLET_WORKLOAD_IDENTITY_PROVIDER }}
+          # or use hardcoded like: workload_identity_provider: projects/889992792607/locations/global/workloadIdentityPools/github-actions/providers/github-actions-provider
+          service-account: ${{ vars.PALLET_SERVICE_ACCOUNT }}
+          # or use hardcoded like: service_account: gh-ap-helloworld@helloworld-shared-0918.iam.gserviceaccount.com
+          token_format: access_token
+          create_credentials_file: true
+      - name: Run Renovate
+        uses: renovatebot/github-action@822441559e94f98b67b82d97ab89fe3003b0a247 # v44.2.0
+        env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_ONBOARDING: "false"
+          RENOVATE_USERNAME: "coopnorge-renovate[bot]"
+          RENOVATE_GIT_AUTHOR: "coopnorge-renovate <121964725+coopnorge-renovate[bot]@users.noreply.github.com>"
+          RENOVATE_PLATFORM_COMMIT: "true"
+          RENOVATE_FORCE: "true"
+          RENOVATE_HOST_RULES: '[{"matchHost":"europe-docker.pkg.dev","token":"${{ steps.gcp-auth.outputs.access_token }}"}]'
+          RENOVATE_PR_BODY_TEMPLATE: "{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}{{{configDescription}}}{{{controls}}}{{{footer}}}"
+          LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
+        with:
+          configurationFile: .github/renovate.json
+          token: ${{ steps.get_token.outputs.token }}
 ```
 
 ## Troubleshooting

--- a/docs/index.md
+++ b/docs/index.md
@@ -193,6 +193,7 @@ For now you also need a GitHub action job for running renovate. Save this to
 
 ```yaml
 on:
+  ## for OCI updates it is important to trigger on tags
   push:
     tags:
       - "v*"

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,8 +64,8 @@ other relevant targets for the tech stack.
 package main
 
 import (
-  //mage:import
-  _ "github.com/coopnorge/mage/targets/goapp"
+    //mage:import
+    _ "github.com/coopnorge/mage/targets/goapp"
 )
 ```
 
@@ -91,8 +91,8 @@ import (
 package main
 
 import (
-  //mage:import
-  _ "github.com/coopnorge/mage/targets/golib"
+    //mage:import
+    _ "github.com/coopnorge/mage/targets/golib"
 )
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -180,84 +180,52 @@ need a renovate config. Save this in `.github/renovate.json5`
 
 ```json5
 {
-  "extends": ["github>coopnorge/github-workflow-renovate"],
-  "packageRules": [
+  extends: ["github>coopnorge/github-workflow-renovate"],
+  packageRules: [
     {
-      "matchDatasources": [
-        "helm"
-      ],
-      "automerge": true,
-      "rebaseWhen": "behind-base-branch",
-      "minimumReleaseAge": "0 days",
+      matchDatasources: ["helm"],
+      automerge: true,
+      rebaseWhen: "behind-base-branch",
+      minimumReleaseAge: "0 days",
     },
     {
-      "matchManagers": [
-        "helm-values"
-      ],
-      "matchDatasources": [
-        "docker"
-      ],
-      "rebaseWhen": "behind-base-branch",
-      "prHourlyLimit": 0,
-      "minimumReleaseAge": "0 days",
+      matchManagers: ["helm-values"],
+      matchDatasources: ["docker"],
+      rebaseWhen: "behind-base-branch",
+      prHourlyLimit: 0,
+      minimumReleaseAge: "0 days",
     },
     {
-      "branchPrefix": "helm/dev/",
-      "matchManagers": [
-        "helm-values"
-      ],
-      "matchDatasources": [
-        "docker"
-      ],
-      "automerge": true,
-      "matchFileNames": [
-        "/(^|/)values-dev.yaml$/"
-      ],
-      "addLabels": [
-        "development"
-      ],
-      "prHourlyLimit": 0
+      branchPrefix: "helm/dev/",
+      matchManagers: ["helm-values"],
+      matchDatasources: ["docker"],
+      automerge: true,
+      matchFileNames: ["/(^|/)values-dev.yaml$/"],
+      addLabels: ["development"],
+      prHourlyLimit: 0,
     },
     {
-      "branchPrefix": "helm/staging/",
-      "matchManagers": [
-        "helm-values"
-      ],
-      "matchDatasources": [
-        "docker"
-      ],
-      "automerge": true,
-      "matchFileNames": [
-        "/(^|/)values-staging.yaml$/"
-      ],
-      "addLabels": [
-        "staging"
-      ],
-      "prHourlyLimit": 0
+      branchPrefix: "helm/staging/",
+      matchManagers: ["helm-values"],
+      matchDatasources: ["docker"],
+      automerge: true,
+      matchFileNames: ["/(^|/)values-staging.yaml$/"],
+      addLabels: ["staging"],
+      prHourlyLimit: 0,
     },
     {
-      "branchPrefix": "helm/production/",
-      "matchManagers": [
-        "helm-values"
-      ],
-      "matchDatasources": [
-        "docker"
-      ],
-      "automerge": true,
-      "matchFileNames": [
-        "/(^|/)values-production.yaml$/"
-      ],
-      "addLabels": [
-        "production"
-      ],
-      "prHourlyLimit": 0
-    }
+      branchPrefix: "helm/production/",
+      matchManagers: ["helm-values"],
+      matchDatasources: ["docker"],
+      automerge: true,
+      matchFileNames: ["/(^|/)values-production.yaml$/"],
+      addLabels: ["production"],
+      prHourlyLimit: 0,
+    },
   ],
   "helm-values": {
-    "managerFilePatterns": [
-      "/(^|/)values(-\\w+)?\\.ya?ml$/"
-    ]
-  }
+    managerFilePatterns: ["/(^|/)values(-\\w+)?\\.ya?ml$/"],
+  },
 }
 ```
 
@@ -271,7 +239,6 @@ Save this to `.github/workflows/renovate.yaml`
 > make sure update the values to your own repo settings
 
 ```yaml
-
 on:
   push:
     tags:

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -44,7 +44,6 @@ func Validate(dockerfileContent string) error {
 func BuildAndPush(dockerfileContent, platforms, image, dockerContext, imagePath, metadatafile, app, binary string, shouldPush bool) error {
 	versionTag := getVersionTag()
 	versionTaggedImage := fmt.Sprintf("%s:%s", image, versionTag)
-	OCITaggedImage := fmt.Sprintf("%s:%s/%s", image, "mage/oci", versionTag)
 	latestImage := fmt.Sprintf("%s:latest", image)
 
 	repoURL, err := git.RepoURL()
@@ -165,10 +164,8 @@ func ParseMetadata(filepath string) (Metadata, error) {
 	}, nil
 }
 
-type (
-	binaryImage  = map[string]string
-	binaryImages = map[string]binaryImage
-)
+type binaryImage = map[string]string
+type binaryImages = map[string]binaryImage
 
 // AppImages ...
 type AppImages = map[string]binaryImages
@@ -229,7 +226,7 @@ func getTag(imageName string) string {
 
 func createDirForOutput(file string) error {
 	dir := path.Dir(file)
-	return os.MkdirAll(dir, 0o700)
+	return os.MkdirAll(dir, 0700)
 }
 
 func getVersionTag() string {

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -82,6 +82,7 @@ func BuildAndPush(dockerfileContent, platforms, image, dockerContext, imagePath,
 		"--output", fmt.Sprintf("type=image,push=%v", shouldPush),
 		"--output", fmt.Sprintf("type=oci,dest=%s", imagePath),
 		"-t", versionTaggedImage,
+		"-t", OCITaggedImage,
 	}
 
 	if !shouldPush {

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -44,7 +44,7 @@ func Validate(dockerfileContent string) error {
 func BuildAndPush(dockerfileContent, platforms, image, dockerContext, imagePath, metadatafile, app, binary string, shouldPush bool) error {
 	versionTag := getVersionTag()
 	versionTaggedImage := fmt.Sprintf("%s:%s", image, versionTag)
-	OCITaggedImage := fmt.Sprintf("%s:%s/%s", image, "mage/oci", versionTag)
+	OCITaggedImage := fmt.Sprintf("%s:%s-%s", image, "mage_oci", versionTag)
 	latestImage := fmt.Sprintf("%s:latest", image)
 
 	repoURL, err := git.RepoURL()

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -44,6 +44,7 @@ func Validate(dockerfileContent string) error {
 func BuildAndPush(dockerfileContent, platforms, image, dockerContext, imagePath, metadatafile, app, binary string, shouldPush bool) error {
 	versionTag := getVersionTag()
 	versionTaggedImage := fmt.Sprintf("%s:%s", image, versionTag)
+	OCITaggedImage := fmt.Sprintf("%s:%s/%s", image, "mage/oci", versionTag)
 	latestImage := fmt.Sprintf("%s:latest", image)
 
 	repoURL, err := git.RepoURL()
@@ -164,8 +165,10 @@ func ParseMetadata(filepath string) (Metadata, error) {
 	}, nil
 }
 
-type binaryImage = map[string]string
-type binaryImages = map[string]binaryImage
+type (
+	binaryImage  = map[string]string
+	binaryImages = map[string]binaryImage
+)
 
 // AppImages ...
 type AppImages = map[string]binaryImages
@@ -226,7 +229,7 @@ func getTag(imageName string) string {
 
 func createDirForOutput(file string) error {
 	dir := path.Dir(file)
-	return os.MkdirAll(dir, 0700)
+	return os.MkdirAll(dir, 0o700)
 }
 
 func getVersionTag() string {

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -82,7 +82,6 @@ func BuildAndPush(dockerfileContent, platforms, image, dockerContext, imagePath,
 		"--output", fmt.Sprintf("type=image,push=%v", shouldPush),
 		"--output", fmt.Sprintf("type=oci,dest=%s", imagePath),
 		"-t", versionTaggedImage,
-		"-t", OCITaggedImage,
 	}
 
 	if !shouldPush {

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -44,7 +44,7 @@ func Validate(dockerfileContent string) error {
 func BuildAndPush(dockerfileContent, platforms, image, dockerContext, imagePath, metadatafile, app, binary string, shouldPush bool) error {
 	versionTag := getVersionTag()
 	versionTaggedImage := fmt.Sprintf("%s:%s", image, versionTag)
-	OCITaggedImage := fmt.Sprintf("%s:%s-%s", image, "mage_oci", versionTag)
+	OCITaggedImage := fmt.Sprintf("%s:%s/%s", image, "mage/oci", versionTag)
 	latestImage := fmt.Sprintf("%s:latest", image)
 
 	repoURL, err := git.RepoURL()

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -119,11 +119,6 @@ func latestTag(pattern string) (string, error) {
 
 // OnMainBranch returns true the current branch is the main branch
 func onMainBranch() (bool, error) {
-	// in gitub use github env var to get branch
-	//githubRef, ok := os.LookupEnv("GITHUB_HEAD_REF")
-	//if ok {
-	//	return githubRef == "refs/heads/main", nil
-	//}
 	branch, err := sh.Output("git", "rev-parse", "--abbrev-ref", "HEAD")
 	if err != nil {
 		return false, err

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/coopnorge/mage/internal/core"
+	"github.com/coopnorge/mage/internal/github"
 	"github.com/magefile/mage/sh"
 )
 
@@ -83,7 +84,7 @@ func DiffToMain() ([]string, error) {
 
 // DiffToTagPattern returns a list of files that have been changed
 // compared to the most recent tags of a certain pattern.
-func DiffToTagPattern(target string) ([]string, error) {
+func DiffToTagPattern(releasePrefix string) ([]string, error) {
 	// git diff
 	// --name-only # only list file names
 	// --no-renames # rename of file is shown as delete and add
@@ -103,9 +104,14 @@ func DiffToTagPattern(target string) ([]string, error) {
 	}
 
 	if onMain {
-		ref, err = latestTag(target)
+		releaseRef, err := github.GetLatestReleaseTagWithPrefix(releasePrefix)
 		if err != nil {
 			return changedFiles, err
+		}
+		// if no relelease is found, compare against main. next release should
+		// create release
+		if releaseRef != "" {
+			ref = releaseRef
 		}
 	}
 
@@ -115,13 +121,6 @@ func DiffToTagPattern(target string) ([]string, error) {
 	}
 	changedFiles = append(changedFiles, strings.Split(gitDiff, "\n")...)
 	return changedFiles, nil
-}
-
-// LatestTag finds the latest tag based on a tag pattern. If tag is not found
-// it will return an error
-func latestTag(pattern string) (string, error) {
-	// add exlucde on "*-*" removes all alpha/beta/rc etc from the list
-	return sh.Output("git", "describe", "--tags", "--abbrev=0", "--match", pattern, "--exclude", "*-*")
 }
 
 // OnMainBranch returns true the current branch is the main branch

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -120,10 +120,10 @@ func latestTag(pattern string) (string, error) {
 // OnMainBranch returns true the current branch is the main branch
 func onMainBranch() (bool, error) {
 	// in gitub use github env var to get branch
-	githubRef, ok := os.LookupEnv("GITHUB_HEAD_REF")
-	if ok {
-		return githubRef == "refs/heads/main", nil
-	}
+	//githubRef, ok := os.LookupEnv("GITHUB_HEAD_REF")
+	//if ok {
+	//	return githubRef == "refs/heads/main", nil
+	//}
 	branch, err := sh.Output("git", "rev-parse", "--abbrev-ref", "HEAD")
 	if err != nil {
 		return false, err

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -124,7 +124,7 @@ func onMainBranch() (bool, error) {
 	if ok {
 		return githubRef == "refs/heads/main", nil
 	}
-	branch, err := sh.Output("git", "ref-parse", "--abbrev-ref", "HEAD")
+	branch, err := sh.Output("git", "rev-parse", "--abbrev-ref", "HEAD")
 	if err != nil {
 		return false, err
 	}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -114,12 +114,11 @@ func DiffToTagPattern(releasePrefix string) ([]string, error) {
 		// TODO: implement native model to do changes against github api
 		if releaseRef == "" {
 			changedFilesFromEnv, ok := os.LookupEnv("CHANGES")
-			if ok {
-				changedFiles = strings.Split(changedFilesFromEnv, ",")
-				return changedFiles, nil
-			} else {
-				return nil, fmt.Errorf("The env var $CHANGES is required but not found. This is required to detect changes on main")
+			if !ok {
+				return nil, fmt.Errorf("the environment varariable $CHANGES is required but not found. This is required to detect changes on main")
 			}
+			changedFiles = strings.Split(changedFilesFromEnv, ",")
+			return changedFiles, nil
 		}
 		ref = releaseRef
 		currentCommit, err := getTimeStampOfCurrentCommit()
@@ -129,7 +128,6 @@ func DiffToTagPattern(releasePrefix string) ([]string, error) {
 		if currentCommit.Before(createdAt) || currentCommit.Equal(createdAt) {
 			return nil, fmt.Errorf("current commit creation date (%s) is created before or is equal the most recent release %s (%s)", currentCommit.String(), ref, createdAt.String())
 		}
-
 	}
 
 	gitDiff, err := sh.Output("git", "diff", "--name-only", "--no-renames", ref)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -81,6 +81,56 @@ func DiffToMain() ([]string, error) {
 	return changedFiles, nil
 }
 
+// DiffToTagPattern returns a list of files that have been changed
+// compared to the most recent tags of a certain pattern.
+func DiffToTagPattern(target string) ([]string, error) {
+	// git diff
+	// --name-only # only list file names
+	// --no-renames # rename of file is shown as delete and add
+
+	changedFiles := []string{}
+	ref := "origin/main"
+	onMain, err := onMainBranch()
+	if err != nil {
+		return changedFiles, err
+	}
+
+	if onMain {
+		ref, err = latestTag(target)
+		if err != nil {
+			return changedFiles, err
+		}
+	}
+
+	gitDiff, err := sh.Output("git", "diff", "--name-only", "--no-renames", ref)
+	if err != nil {
+		return changedFiles, err
+	}
+	changedFiles = append(changedFiles, strings.Split(gitDiff, "\n")...)
+	return changedFiles, nil
+}
+
+// LatestTag finds the latest tag based on a tag pattern. If tag is not found
+// it will return an error
+func latestTag(pattern string) (string, error) {
+	// add exlucde on "*-*" removes all alpha/beta/rc etc from the list
+	return sh.Output("git", "describe", "--tags", "--abbrev=0", "--match", pattern, "--exclude", "*-*")
+}
+
+// OnMainBranch returns true the current branch is the main branch
+func onMainBranch() (bool, error) {
+	// in gitub use github env var to get branch
+	githubRef, ok := os.LookupEnv("GITHUB_HEAD_REF")
+	if ok {
+		return githubRef == "refs/heads/main", nil
+	}
+	branch, err := sh.Output("git", "ref-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return false, err
+	}
+	return branch == "main", nil
+}
+
 func checkBranch(branch string) error {
 	return sh.Run("git", "rev-parse", "--verify", branch)
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -109,18 +109,27 @@ func DiffToTagPattern(releasePrefix string) ([]string, error) {
 		if err != nil {
 			return nil, fmt.Errorf("getting releases from github failed: %w", err)
 		}
-		// if no relelease is found, compare against main. next release should
-		// create release
-		if releaseRef != "" {
-			ref = releaseRef
-			currentCommit, err := getTimeStampOfCurrentCommit()
-			if err != nil {
-				return nil, fmt.Errorf("failed to get timetamp of current commit: %w ", err)
-			}
-			if currentCommit.Before(createdAt) || currentCommit.Equal(createdAt) {
-				return nil, fmt.Errorf("current commit creation date (%s) is created before or is equal the most recent release %s (%s)", currentCommit.String(), ref, createdAt.String())
+		// if no relelease is found, use CHANGES from dorny path filter. next release should
+		// create release.
+		// TODO: implement native model to do changes against github api
+		if releaseRef == "" {
+			changedFilesFromEnv, ok := os.LookupEnv("CHANGES")
+			if ok {
+				changedFiles = strings.Split(changedFilesFromEnv, ",")
+				return changedFiles, nil
+			} else {
+				return nil, fmt.Errorf("The env var $CHANGES is required but not found. This is required to detect changes on main")
 			}
 		}
+		ref = releaseRef
+		currentCommit, err := getTimeStampOfCurrentCommit()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get timetamp of current commit: %w ", err)
+		}
+		if currentCommit.Before(createdAt) || currentCommit.Equal(createdAt) {
+			return nil, fmt.Errorf("current commit creation date (%s) is created before or is equal the most recent release %s (%s)", currentCommit.String(), ref, createdAt.String())
+		}
+
 	}
 
 	gitDiff, err := sh.Output("git", "diff", "--name-only", "--no-renames", ref)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/coopnorge/mage/internal/core"
 	"github.com/coopnorge/mage/internal/github"
@@ -100,18 +101,25 @@ func DiffToTagPattern(releasePrefix string) ([]string, error) {
 	ref := "origin/main"
 	onMain, err := onMainBranch()
 	if err != nil {
-		return changedFiles, err
+		return nil, fmt.Errorf("failed to check if commit is on main branch: %w", err)
 	}
 
 	if onMain {
-		releaseRef, err := github.GetLatestReleaseTagWithPrefix(releasePrefix)
+		releaseRef, createdAt, err := github.GetLatestReleaseTagWithPrefix(releasePrefix)
 		if err != nil {
-			return changedFiles, err
+			return nil, fmt.Errorf("getting releases from github failed: %w", err)
 		}
 		// if no relelease is found, compare against main. next release should
 		// create release
 		if releaseRef != "" {
 			ref = releaseRef
+			currentCommit, err := getTimeStampOfCurrentCommit()
+			if err != nil {
+				return nil, fmt.Errorf("failed to get timetamp of current commit: %w ", err)
+			}
+			if currentCommit.Before(createdAt) || currentCommit.Equal(createdAt) {
+				return nil, fmt.Errorf("current commit creation date (%s) is created before or is equal the most recent release %s (%s)", currentCommit.String(), ref, createdAt.String())
+			}
 		}
 	}
 
@@ -144,6 +152,18 @@ func IsTracked(path string) bool {
 // CurrentBranch returns the current branch
 func CurrentBranch() (string, error) {
 	return sh.Output("git", "rev-parse", "--abbrev-ref", "HEAD")
+}
+
+func getTimeStampOfCurrentCommit() (time.Time, error) {
+	out, err := sh.Output("git", "show", "--no-patch", `--format=%cI`)
+	if err != nil {
+		return time.Unix(0, 0), fmt.Errorf("getting timestamp of commit using git failed: %w", err)
+	}
+	timestamp, err := time.Parse(time.RFC3339, out)
+	if err != nil {
+		return time.Unix(0, 0), fmt.Errorf("failed to parse timestamp %s: %w", out, err)
+	}
+	return timestamp, nil
 }
 
 // Worktree creates a new worktree for the given branch.

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -89,6 +89,13 @@ func DiffToTagPattern(target string) ([]string, error) {
 	// --no-renames # rename of file is shown as delete and add
 
 	changedFiles := []string{}
+
+	changedFilesFromEnv, ok := os.LookupEnv("CHANGED_FILES")
+	if ok {
+		changedFiles = strings.Split(changedFilesFromEnv, ",")
+		return changedFiles, nil
+	}
+
 	ref := "origin/main"
 	onMain, err := onMainBranch()
 	if err != nil {

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -4,10 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"slices"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	"github.com/magefile/mage/sh"
@@ -157,4 +160,132 @@ func validateCommentBody(filename string) error {
 		return fmt.Errorf("body is %d characters which is more than the max of 65536", utf8.RuneCountInString(string(body)))
 	}
 	return nil
+}
+
+type options struct {
+	httpClient *http.Client
+	token      string
+	baseURL    string
+	owner      string
+	repo       string
+}
+
+// Option are options for the github http client
+type Option func(*options)
+
+func defaultOptions() (*options, error) {
+	opts := &options{
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+
+	// token fallback
+	if t, ok := os.LookupEnv("GITHUB_TOKEN"); ok {
+		opts.token = t
+	} else {
+		return nil, fmt.Errorf("missing GITHUB_TOKEN")
+	}
+
+	// repo fallback
+	repo, err := getRepoInfo()
+	if err != nil && InCI() {
+		return nil, fmt.Errorf("failed to get repo info: %w", err)
+	}
+	opts.owner = repo.Owner
+	opts.repo = repo.Repo
+	opts.baseURL = repo.APIURL
+
+	return opts, nil
+}
+
+// WithHTTPClient overrides the http client for github api requests. Mainly useful
+// when with testing
+func WithHTTPClient(c *http.Client) Option {
+	return func(o *options) {
+		o.httpClient = c
+	}
+}
+
+// GetLatestReleaseTagWithPrefix gets the latest release filtred by a prefix
+// of the release name (not the tag name). It returns the tag and a error. If
+// no release is found the tag will be an empty string.
+func GetLatestReleaseTagWithPrefix(prefix string, opts ...Option) (string, error) {
+	o, err := defaultOptions()
+	if err != nil {
+		return "", err
+	}
+
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	url := fmt.Sprintf("%s/repos/%s/%s/releases", o.baseURL, o.owner, o.repo)
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	req.Header.Set("Authorization", "Bearer "+o.token)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := o.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to call GitHub API: %w", err)
+	}
+
+	defer func() {
+		err := resp.Body.Close()
+		if err != nil {
+			fmt.Printf("Failed to close body, ignoring: %s\n", err)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("got status %d, expected is %d", resp.StatusCode, http.StatusOK)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	var releases []ghRelease
+	if err := json.Unmarshal(body, &releases); err != nil {
+		return "", fmt.Errorf("failed to parse: %s\nerr: %w", string(body), err)
+	}
+
+	for _, r := range releases {
+		if strings.HasPrefix(r.Name, prefix) {
+			return r.TagName, nil
+		}
+	}
+	return "", nil
+}
+
+type ghRelease struct {
+	Name       string `json:"name"`
+	TagName    string `json:"tag_name"`
+	Draft      bool   `json:"draft"`
+	Prerelease bool   `json:"prerelease"`
+}
+
+// ghRepo stores information about the repo
+// when running in github actions CI
+type ghRepo struct {
+	Owner  string
+	Repo   string
+	APIURL string
+}
+
+func getRepoInfo() (ghRepo, error) {
+	info := ghRepo{}
+	val, found := os.LookupEnv("GITHUB_REPOSITORY")
+	if !found {
+		return info, fmt.Errorf("environment variable GITHUB_REPOSITORY not found, unable to determine repository info")
+	}
+	url, found := os.LookupEnv("GITHUB_API_URL")
+	if !found {
+		return info, fmt.Errorf("environment variable GITHUB_API_URL not found, unable to determine api url")
+	}
+	info.APIURL = url
+	info.Owner = strings.Split(val, "/")[0]
+	info.Repo = strings.Split(val, "/")[1]
+	return info, nil
 }

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -221,10 +221,11 @@ func GetLatestReleaseTagWithPrefix(prefix string, opts ...Option) (string, error
 	url := fmt.Sprintf("%s/repos/%s/%s/releases", o.baseURL, o.owner, o.repo)
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
-	req.Header.Set("Authorization", "Bearer "+o.token)
 	if err != nil {
 		return "", err
 	}
+
+	req.Header.Set("Authorization", "Bearer "+o.token)
 
 	resp, err := o.httpClient.Do(req)
 	if err != nil {

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"slices"
+	"sort"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -208,28 +209,28 @@ func WithHTTPClient(c *http.Client) Option {
 // GetLatestReleaseTagWithPrefix gets the latest release filtred by a prefix
 // of the release name (not the tag name). It returns the tag and a error. If
 // no release is found the tag will be an empty string.
-func GetLatestReleaseTagWithPrefix(prefix string, opts ...Option) (string, error) {
+func GetLatestReleaseTagWithPrefix(prefix string, opts ...Option) (string, time.Time, error) {
 	o, err := defaultOptions()
 	if err != nil {
-		return "", err
+		return "", time.Now(), err
 	}
 
 	for _, opt := range opts {
 		opt(o)
 	}
 
-	url := fmt.Sprintf("%s/repos/%s/%s/releases", o.baseURL, o.owner, o.repo)
+	url := fmt.Sprintf("%s/repos/%s/%s/releases?per_page=100", o.baseURL, o.owner, o.repo)
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
-		return "", err
+		return "", time.Now(), err
 	}
 
 	req.Header.Set("Authorization", "Bearer "+o.token)
 
 	resp, err := o.httpClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("failed to call GitHub API: %w", err)
+		return "", time.Now(), fmt.Errorf("failed to call GitHub API: %w", err)
 	}
 
 	defer func() {
@@ -240,31 +241,42 @@ func GetLatestReleaseTagWithPrefix(prefix string, opts ...Option) (string, error
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("got status %d, expected is %d", resp.StatusCode, http.StatusOK)
+		return "", time.Now(), fmt.Errorf("got status %d, expected is %d", resp.StatusCode, http.StatusOK)
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", err
+		return "", time.Now(), err
 	}
 	var releases []ghRelease
 	if err := json.Unmarshal(body, &releases); err != nil {
-		return "", fmt.Errorf("failed to parse: %s\nerr: %w", string(body), err)
+		return "", time.Now(), fmt.Errorf("failed to parse: %s\nerr: %w", string(body), err)
 	}
+	// sort releases, gh does not state ordering of releases
+	sort.Slice(releases, func(i, j int) bool {
+		return releases[i].CreatedAt.After(releases[j].CreatedAt)
+	})
 
 	for _, r := range releases {
+		if r.Draft {
+			continue
+		}
+		if r.Prerelease {
+			continue
+		}
 		if strings.HasPrefix(r.Name, prefix) {
-			return r.TagName, nil
+			return r.TagName, r.CreatedAt, nil
 		}
 	}
-	return "", nil
+	return "", time.Now(), nil
 }
 
 type ghRelease struct {
-	Name       string `json:"name"`
-	TagName    string `json:"tag_name"`
-	Draft      bool   `json:"draft"`
-	Prerelease bool   `json:"prerelease"`
+	Name       string    `json:"name"`
+	TagName    string    `json:"tag_name"`
+	Draft      bool      `json:"draft"`
+	Prerelease bool      `json:"prerelease"`
+	CreatedAt  time.Time `json:"created_at"`
 }
 
 // ghRepo stores information about the repo

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -1,0 +1,87 @@
+package github_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/coopnorge/mage/internal/github"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetLatestReleaseTagWithPrefix(t *testing.T) {
+	tests := []struct {
+		name       string
+		payload    string
+		prefix     string
+		httpStatus int
+		want       string
+		wantErr    bool
+	}{
+		{
+			name: "Working example",
+			payload: `[
+		       {"name": "v1.2.0", "tag_name": "v1.2.0", "draft": false, "prerelease": false},
+		       {"name": "test-1.0.0", "tag_name": "test-1.0.0", "draft": false, "prerelease": false}
+	        ]`,
+			prefix:     "v",
+			httpStatus: 200,
+			want:       "v1.2.0",
+			wantErr:    false,
+		},
+		{
+			name: "No version",
+			payload: `[
+		       {"name": "1.2.0", "tag_name": "v1.2.0", "draft": false, "prerelease": false},
+		       {"name": "test-1.0.0", "tag_name": "test-1.0.0", "draft": false, "prerelease": false}
+	        ]`,
+			prefix:     "v",
+			httpStatus: 200,
+			want:       "",
+			wantErr:    false,
+		},
+		{
+			name: "Failed payload",
+			payload: `[
+		       {"name": "1.2.0", "tag_name": "v1.2.0", "draft": false, "prerelease": false},
+		       test-1.0.0", "tag_name": "test-1.0.0", "draft": false, "prerelease": false}
+	        ]`,
+			prefix:     "v",
+			httpStatus: 200,
+			want:       "",
+			wantErr:    true,
+		},
+		{
+			name:       "Failed request",
+			payload:    "503 Fail",
+			prefix:     "v",
+			httpStatus: 500,
+			want:       "",
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(tt.httpStatus)
+			_, err := w.Write([]byte(tt.payload))
+			_ = err
+		}))
+		defer server.Close()
+
+		t.Setenv("GITHUB_TOKEN", "test")
+		t.Setenv("GITHUB_REPOSITORY", "test/test")
+		t.Setenv("GITHUB_API_URL", server.URL)
+
+		tag, err := github.GetLatestReleaseTagWithPrefix(
+			tt.prefix,
+			github.WithHTTPClient(server.Client()),
+		)
+		if tt.wantErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+		}
+		assert.Equal(t, tt.want, tag)
+	}
+}

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -19,10 +19,47 @@ func TestGetLatestReleaseTagWithPrefix(t *testing.T) {
 		wantErr    bool
 	}{
 		{
-			name: "Working example",
+			name: "it should work",
 			payload: `[
-		       {"name": "v1.2.0", "tag_name": "v1.2.0", "draft": false, "prerelease": false},
-		       {"name": "test-1.0.0", "tag_name": "test-1.0.0", "draft": false, "prerelease": false}
+		       {"name": "v1.2.0", "tag_name": "v1.2.0", "draft": false, "prerelease": false, "created_at": "2013-02-27T19:35:32Z"},
+		       {"name": "test-1.0.0", "tag_name": "test-1.0.0", "draft": false, "prerelease": false, "created_at": "2013-02-27T19:35:32Z"}
+	        ]`,
+			prefix:     "v",
+			httpStatus: 200,
+			want:       "v1.2.0",
+			wantErr:    false,
+		},
+		{
+			name: "ordering should work",
+			payload: `[
+		       {"name": "v1.2.0", "tag_name": "v1.2.0", "draft": false, "prerelease": false, "created_at": "2013-02-27T19:35:32Z"},
+		       {"name": "v1.3.0", "tag_name": "v1.3.0", "draft": false, "prerelease": false, "created_at": "2014-02-27T19:35:32Z"},
+		       {"name": "test-1.0.0", "tag_name": "test-1.0.0", "draft": false, "prerelease": false, "created_at": "2013-02-27T19:35:32Z"}
+	        ]`,
+			prefix:     "v",
+			httpStatus: 200,
+			want:       "v1.3.0",
+			wantErr:    false,
+		},
+
+		{
+			name: "Skip draft",
+			payload: `[
+		       {"name": "v1.3.0", "tag_name": "v1.2.0", "draft": true, "prerelease": false, "created_at": "2013-02-27T19:35:32Z"},
+		       {"name": "v1.2.0", "tag_name": "v1.2.0", "draft": false, "prerelease": false, "created_at": "2013-02-27T19:35:32Z"},
+		       {"name": "test-1.0.0", "tag_name": "test-1.0.0", "draft": false, "prerelease": false, "created_at": "2013-02-27T19:35:32Z"}
+	        ]`,
+			prefix:     "v",
+			httpStatus: 200,
+			want:       "v1.2.0",
+			wantErr:    false,
+		},
+		{
+			name: "Skip prerelease",
+			payload: `[
+		       {"name": "v1.3.0", "tag_name": "v1.2.0", "draft": false, "prerelease": true, "created_at": "2013-02-27T19:35:32Z"},
+		       {"name": "v1.2.0", "tag_name": "v1.2.0", "draft": false, "prerelease": false, "created_at": "2013-02-27T19:35:32Z"},
+		       {"name": "test-1.0.0", "tag_name": "test-1.0.0", "draft": false, "prerelease": false, "created_at": "2013-02-27T19:35:32Z"}
 	        ]`,
 			prefix:     "v",
 			httpStatus: 200,
@@ -32,8 +69,9 @@ func TestGetLatestReleaseTagWithPrefix(t *testing.T) {
 		{
 			name: "No version",
 			payload: `[
-		       {"name": "1.2.0", "tag_name": "v1.2.0", "draft": false, "prerelease": false},
-		       {"name": "test-1.0.0", "tag_name": "test-1.0.0", "draft": false, "prerelease": false}
+		       {"name": "v1.2.0", "tag_name": "v1.2.0", "draft": true, "prerelease": false, "created_at": "2013-02-27T19:35:32Z"},
+		       {"name": "1.2.0", "tag_name": "v1.2.0", "draft": false, "prerelease": false, "created_at": "2013-02-27T19:35:32Z"},
+		       {"name": "test-1.0.0", "tag_name": "test-1.0.0", "draft": false, "prerelease": false, "created_at": "2013-02-27T19:35:32Z"}
 	        ]`,
 			prefix:     "v",
 			httpStatus: 200,
@@ -43,8 +81,8 @@ func TestGetLatestReleaseTagWithPrefix(t *testing.T) {
 		{
 			name: "Failed payload",
 			payload: `[
-		       {"name": "1.2.0", "tag_name": "v1.2.0", "draft": false, "prerelease": false},
-		       test-1.0.0", "tag_name": "test-1.0.0", "draft": false, "prerelease": false}
+		       {"name": "1.2.0", "tag_name": "v1.2.0", "draft": false, "prerelease": false, "created_at": "2013-02-27T19:35:32Z"},
+		       test-1.0.0", "tag_name": "test-1.0.0", "draft": false, "prerelease": false, "created_at": "2013-02-27T19:35:32Z"}
 	        ]`,
 			prefix:     "v",
 			httpStatus: 200,
@@ -62,26 +100,30 @@ func TestGetLatestReleaseTagWithPrefix(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(tt.httpStatus)
-			_, err := w.Write([]byte(tt.payload))
-			_ = err
-		}))
-		defer server.Close()
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.httpStatus)
+				_, err := w.Write([]byte(tt.payload))
+				assert.NoError(t, err)
+			}))
+			t.Cleanup(func() {
+				server.Close()
+			})
 
-		t.Setenv("GITHUB_TOKEN", "test")
-		t.Setenv("GITHUB_REPOSITORY", "test/test")
-		t.Setenv("GITHUB_API_URL", server.URL)
+			t.Setenv("GITHUB_TOKEN", "test")
+			t.Setenv("GITHUB_REPOSITORY", "test/test")
+			t.Setenv("GITHUB_API_URL", server.URL)
 
-		tag, err := github.GetLatestReleaseTagWithPrefix(
-			tt.prefix,
-			github.WithHTTPClient(server.Client()),
-		)
-		if tt.wantErr {
-			assert.Error(t, err)
-		} else {
-			assert.NoError(t, err)
-		}
-		assert.Equal(t, tt.want, tag)
+			tag, _, err := github.GetLatestReleaseTagWithPrefix(
+				tt.prefix,
+				github.WithHTTPClient(server.Client()),
+			)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.want, tag)
+		})
 	}
 }

--- a/internal/golang/golang.go
+++ b/internal/golang/golang.go
@@ -112,8 +112,8 @@ func FindGoSourceCodeFolders(base string) ([]string, error) {
 
 // HasChanges checks if the current branch has any Go changes compared
 // to the main branch
-func HasChanges(goSourceCodeFolders []string) (bool, error) {
-	changedFiles, err := git.DiffToMain()
+func HasChanges(goSourceCodeFolders []string, pattern string) (bool, error) {
+	changedFiles, err := git.DiffToTagPattern(pattern)
 	if err != nil {
 		return false, err
 	}

--- a/internal/targets/golang/golang.go
+++ b/internal/targets/golang/golang.go
@@ -116,13 +116,13 @@ func downloadModules(_ context.Context, directory string) error {
 
 // Changes implements a target that check if the current branch has changes
 // related to main branch
-func Changes(_ context.Context) error {
+func Changes(_ context.Context, pattern string) error {
 	directories, err := golang.FindGoSourceCodeFolders(".")
 	if err != nil {
 		return err
 	}
 
-	changes, err := golang.HasChanges(directories)
+	changes, err := golang.HasChanges(directories, pattern)
 	if err != nil {
 		return err
 	}

--- a/targets/goapp/golang.go
+++ b/targets/goapp/golang.go
@@ -257,7 +257,7 @@ func binaryOutputBasePath(app string) string {
 // Changes returns the string true or false depending on the fact that
 // the current branch contains changes compared to the main branch.
 func (Go) Changes(ctx context.Context) error {
-	mg.CtxDeps(ctx, golangTargets.Changes)
+	mg.CtxDeps(ctx, mg.F(golangTargets.Changes, "mage/oci/*"))
 	return nil
 }
 

--- a/targets/goapp/golang.go
+++ b/targets/goapp/golang.go
@@ -257,7 +257,7 @@ func binaryOutputBasePath(app string) string {
 // Changes returns the string true or false depending on the fact that
 // the current branch contains changes compared to the main branch.
 func (Go) Changes(ctx context.Context) error {
-	mg.CtxDeps(ctx, mg.F(golangTargets.Changes, "v*"))
+	mg.CtxDeps(ctx, mg.F(golangTargets.Changes, "Go OCI Release"))
 	return nil
 }
 

--- a/targets/goapp/golang.go
+++ b/targets/goapp/golang.go
@@ -257,7 +257,7 @@ func binaryOutputBasePath(app string) string {
 // Changes returns the string true or false depending on the fact that
 // the current branch contains changes compared to the main branch.
 func (Go) Changes(ctx context.Context) error {
-	mg.CtxDeps(ctx, mg.F(golangTargets.Changes, "mage/oci/*"))
+	mg.CtxDeps(ctx, mg.F(golangTargets.Changes, "v*"))
 	return nil
 }
 

--- a/targets/golib/golang.go
+++ b/targets/golib/golang.go
@@ -66,7 +66,7 @@ func (Go) LintFix(ctx context.Context) error {
 // Changes returns the string true or false depending on the fact that
 // the current branch contains changes compared to the main branch.
 func (Go) Changes(ctx context.Context) error {
-	mg.CtxDeps(ctx, golang.Changes)
+	mg.CtxDeps(ctx, mg.F(golang.Changes, "v*"))
 	return nil
 }
 

--- a/targets/golib/golang.go
+++ b/targets/golib/golang.go
@@ -66,7 +66,7 @@ func (Go) LintFix(ctx context.Context) error {
 // Changes returns the string true or false depending on the fact that
 // the current branch contains changes compared to the main branch.
 func (Go) Changes(ctx context.Context) error {
-	mg.CtxDeps(ctx, mg.F(golang.Changes, "v*"))
+	mg.CtxDeps(ctx, mg.F(golang.Changes, "v"))
 	return nil
 }
 


### PR DESCRIPTION
This will change the when to build what. 

This will do a diff based on a git tag. When a build has been done on main that builds an oci it will set a tag. Next time on main it will do a diff based on this tag. If the diff actually has changes related to this tag. 

### Why?

We used to do this based on the diff which came with the PR event. This PR event was also used on the main branch. If the job is canceled or removed from queue this creates a problem. Also in github actions, jobs in a queue don't have a guaranteed order. Also rerunning a job based on a PR event would rerun certain steps based on the event data. This is not the behavior you want if the artifact is already published. Also the PR invent was a bit hard to get insight to. 


### What will happen here

When a PR is created the, a diff between the main branch and the PR branch is made and based on the files in the diff decisions are made on which part of CI are required to run.
When merged, mage will look for the most recent tag based on a tag pattern and use this tag as a diff target. When this results in a diff, mage will run certain CI (mage ci for golang with OCI build) and when finished write a new tag. So if you rerun this job it won't rerun because the diff between the tag and the head is none. 
This, in the end will give a way more predictable CI. We can also merge the job queue on the main branch resulting less action minutes spend and not being exposed to the order in which jobs run on the main branch.


### How to use this

If set `inputs.tag-based-diff` is set to `true` this behavior is enabled. This is disabled by default to ensure a smooth transition. It is strongly encouraged to enable this. 

### Updating your image tags in helm

When a release is created we can trigger a job to update the OCI tags in your helm values. This is best done via renovate. See examples below. 


Relevant issues https://github.com/coopnorge/mage/issues/356