### PR TITLE
feat: Build multiple Go binaries at once

### DIFF
--- a/targets/goapp/docker.go
+++ b/targets/goapp/docker.go
@@ -131,7 +131,9 @@ func (Docker) BuildImages(ctx context.Context) error {
 
 	deps := []any{}
 	for _, cmd := range cmds {
-		deps = append(deps, mg.F(buildAndPush, cmd.goModule, cmd.binary, shouldPush))
+		for _, binary := range cmd.binaries {
+			deps = append(deps, mg.F(buildAndPush, cmd.goModule, binary, shouldPush))
+		}
 	}
 	mg.CtxDeps(ctx, deps...)
 


### PR DESCRIPTION
Leverage Go's ability to build multiple binaries at once. This should reduce
the build times.
