### PR TITLE
fix: Run TFLint in serial instead of concurrently

### DIFF
--- a/internal/targets/terraform/terraform.go
+++ b/internal/targets/terraform/terraform.go
@@ -62,7 +62,7 @@ func Lint(ctx context.Context) error {
 		lintDirs = append(lintDirs, mg.F(lint, workDir))
 	}
 
-	mg.CtxDeps(ctx, lintDirs...)
+	mg.SerialCtxDeps(ctx, lintDirs...)
 	return nil
 }
 


### PR DESCRIPTION
TFLint is not safe for concurrent use. When we have multiple modules in the same repo, we are trying to lint all of them at the same time, with the same directory for plugins, which causes it to sometime race and tey to write to a busy file, which fails the CI.

The LintFix is already running in serial

Fixes #343
