### PR TITLE
refactor: Run go:lint and go:test in parallel

### DIFF
--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -27,11 +27,11 @@ on:
         description: Run mage go related tasks in "docker" (default) or local
     outputs:
       oci-images:
-        value: ${{ jobs.collector.outputs.oci-images }}
+        value: ${{ jobs.go-build.outputs.oci-images }}
         description: OCI image references.
 
 jobs:
-  lint:
+  go-lint:
     name: Go Lint
     runs-on: ubuntu-24.04
     permissions:
@@ -61,7 +61,7 @@ jobs:
         env:
           GO_RUNTIME: ${{ inputs.go-runtime }}
 
-  test:
+  go-test:
     name: Go Test
     runs-on: ubuntu-24.04
     permissions:
@@ -87,8 +87,11 @@ jobs:
         env:
           GO_RUNTIME: ${{ inputs.go-runtime }}
 
-  goapp:
-    name: Go application CI
+  go-build:
+    name: Go build
+    needs:
+      - go-lint
+      - go-test
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -175,19 +178,3 @@ jobs:
       - name: Show output
         if: always()
         run: tree var/
-
-  collector:
-    name: Results Collector
-    needs:
-      - lint
-      - test
-      - goapp
-    if: always()
-    runs-on: ubuntu-latest
-    permissions: {}
-    outputs:
-      oci-images: ${{ (needs.lint.result == 'success' && needs.test.result == 'success' && needs.goapp.result == 'success') && needs.goapp.outputs.oci-images || '' }}
-    steps:
-      - run: exit 1
-        name: "Catch errors"
-        if: ${{ contains(join(needs.*.result, ','), 'failure') || contains(join(needs.*.result, ','), 'cancelled') }}


### PR DESCRIPTION
They are the most time-consuming steps and running them in parallel improves total ci wait time for a PR.

Downsides are:
- some duplication

Coparision in helloworld:
- current: https://github.com/coopnorge/helloworld/actions/runs/21351333544?pr=3149, total duration: 2:35
- previous: https://github.com/coopnorge/helloworld/actions/runs/21196115165?pr=3141, total duration: 5:29
