### PR TITLE
refactor: Merge go-test and go-build into one job

### DIFF
--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -61,37 +61,8 @@ jobs:
         env:
           GO_RUNTIME: ${{ inputs.go-runtime }}
 
-  go-test:
-    name: Go Test
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Configure access to internal and private GitHub repos
-        run: git config --global url."https://${{ secrets.REVIEWBOT_GITHUB_TOKEN }}:x-oauth-basic@github.com/coopnorge".insteadOf "https://github.com/coopnorge"
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-          cache-dependency-path: "**/go.sum"
-      - name: Install go Tools
-        run: go install tool
-      - name: Check if coop mage has separate build commands
-        id: has-multiple-cmds
-        run: echo "outcome=$(go tool mage -l | grep go:buildBinaries | wc -l)" >> $GITHUB_OUTPUT
-      - name: Run Go Test
-        if: ${{ steps.has-multiple-cmds.outputs.outcome == '1' }}
-        run: "go tool mage -v go:test"
-        env:
-          GO_RUNTIME: ${{ inputs.go-runtime }}
-
   go-build:
     name: Go build
-    needs:
-      - go-lint
-      - go-test
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -145,6 +116,11 @@ jobs:
       - name: Check if coop mage has separate build commands
         id: has-multiple-cmds
         run: echo "outcome=$(go tool mage -l | grep go:buildBinaries | wc -l)" >> $GITHUB_OUTPUT
+      - name: Run Go Test
+        if: ${{ steps.has-multiple-cmds.outputs.outcome == '1' }}
+        run: "go tool mage -v go:test"
+        env:
+          GO_RUNTIME: ${{ inputs.go-runtime }}
         # this block requires coopnorge/mage > v0.10.0
       - name: Download Go modules
         if: ${{ steps.has-multiple-cmds.outputs.outcome == '1' }}


### PR DESCRIPTION
In the current implementation, go-test and go-build are running serially anyway. Merging them into one step removes some of the duplication in run-time and speeds up the CI.

main: https://github.com/coopnorge/helloworld/actions/runs/21389141854?pr=3149 4m 37s
this branch: https://github.com/coopnorge/helloworld/actions/runs/21388946528?pr=3149 3m 55s

Downside: It may push images even when there are lint failures (as long as the tests pass)