### PR TITLE
fix: Don't fail ci if no images build

### DIFF
--- a/targets/goapp/docker.go
+++ b/targets/goapp/docker.go
@@ -145,6 +145,10 @@ func buildAndPush(_ context.Context, app, binary string, shouldPush bool) error 
 }
 
 func writeImageMetadata() error {
+	err := os.MkdirAll(core.OutputDir, 0755)
+	if err != nil {
+		return err
+	}
 	images, err := docker.Images(core.OutputDir)
 	if err != nil {
 		return err


### PR DESCRIPTION
Currently, mage fails ci if no images to build, e.g. https://github.com/coopnorge/pravin-pp/pull/94