### PR TITLE
feat: Instruct golangci-lint to report paths relative to the go.mod

### DIFF
--- a/internal/devtool/golangci-lint/golangci-lint.yml
+++ b/internal/devtool/golangci-lint/golangci-lint.yml
@@ -1,4 +1,6 @@
 version: "2"
+run:
+  relative-path-mode: "gomod"
 linters:
   default: none
   enable:


### PR DESCRIPTION
When running golangci-lint locally with a symlink (or `--config` flag) that points to this config-file, golangci-lint will report the paths relative to the config-file.

This leads to a lot of unneccesary path-parts, but it also breaks hyperlinks to the files in the terminal.

Example lint errors with the default behaviour (`relative-path-mode: "cfg"`):
```
../../../../MY-REPO/src/MY-DIR1/MY-DIR2/MY-FILE.go:16:94: unnecessary leading newline (whitespace)
````

Example lint errors after this PR ( `go.mod` lives in "MY-REPO/src/`):
```
MY-DIR1/MY-DIR2/MY-FILE.go:16:94: unnecessary leading newline (whitespace)
```

Now hyperlinks in the terminal in VSCode will be able to open the file.
