### PR TITLE
fix: Use the provided golangci-lint version as the minimun

### DIFF
--- a/internal/devtool/golangci-lint.go
+++ b/internal/devtool/golangci-lint.go
@@ -56,8 +56,8 @@ func (gl GoLangCILint) versionOK() error {
 	if err != nil {
 		return err
 	}
-	// set constraint that minor minus 2 version should be minimum
-	constraintString := fmt.Sprintf(">= %s.%s", strconv.Itoa(devtool.Segments()[0]), strconv.Itoa(devtool.Segments()[1]-2))
+	// set constraint that minor version should be minimum
+	constraintString := fmt.Sprintf(">= %s.%s", strconv.Itoa(devtool.Segments()[0]), strconv.Itoa(devtool.Segments()[1]))
 	constraint, err := version.NewConstraint(constraintString)
 	if err != nil {
 		return err


### PR DESCRIPTION
The former implementation caused a bug when moving one Go minor version to
another. When accepting -2 minor versions of golangci-lint the code then
accepted a local version of golangci-lint that was not compatible with the new
stable version of Go. Setting lower constraint for using local golangci-lint to
be at least the same minor version as the bundled one fixes the problem as uses
the bundled version when the local version is to old.
