### PR TITLE
chore: Use the latest stable version of Go on GitHub Action

### DIFF
--- a/.github/workflows/goapp.yaml
+++ b/.github/workflows/goapp.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          go-version: "stable"
           cache-dependency-path: "**/go.sum"
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: filter

--- a/.github/workflows/mage.yaml
+++ b/.github/workflows/mage.yaml
@@ -94,7 +94,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          go-version: "stable"
           cache-dependency-path: "**/go.sum"
       - name: Install go Tools
         run: go install tool

--- a/.github/workflows/reusable-catalog-info.yaml
+++ b/.github/workflows/reusable-catalog-info.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          go-version: "stable"
           cache-dependency-path: "**/go.sum"
 
       - name: Install go Tools

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          go-version: "stable"
           cache-dependency-path: "**/go.sum"
       - name: Setup Golangci Lint
         uses: golangci/golangci-lint-action@v9
@@ -74,7 +74,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          go-version: "stable"
           cache-dependency-path: "**/go.sum"
       - name: Install go Tools
         run: go install tool
@@ -138,7 +138,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          go-version: "stable"
           cache-dependency-path: "**/go.sum"
       - name: Install go Tools
         run: go install tool

--- a/.github/workflows/reusable-pallets.yaml
+++ b/.github/workflows/reusable-pallets.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          go-version: "stable"
           cache-dependency-path: "**/go.sum"
       - name: Install go Tools
         run: go install tool

--- a/.github/workflows/reusable-policy-bot.yaml
+++ b/.github/workflows/reusable-policy-bot.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          go-version: "stable"
           cache-dependency-path: "**/go.sum"
       - name: Install go Tools
         run: go install tool

--- a/.github/workflows/reusable-terraform.yaml
+++ b/.github/workflows/reusable-terraform.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          go-version: "stable"
           cache-dependency-path: "**/go.sum"
       - name: Install go Tools
         run: go install tool


### PR DESCRIPTION
Go guaranties backwards compatibility therefor we can safely run GitHub Actions
on the latest stable version of the toolchain and standard library. Allowing
the go version directive in go mod files to set the language version.
