### PR TITLE
feat: Better helm chart status checking

### DIFF
--- a/.github/workflows/reusable-kubernetes.yaml
+++ b/.github/workflows/reusable-kubernetes.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Kubernetes diff
         id: diff
-        run: go tool mage -v k8s:diff
+        run: go tool mage k8s:diff
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/reusable-kubernetes.yaml
+++ b/.github/workflows/reusable-kubernetes.yaml
@@ -20,8 +20,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Add Safedir
-        run: git config --global --add safe.directory "/tmp"
+      - name: Fetch the main branch as well
+        run: git fetch origin $GITHUB_BASE_REF:$GITHUB_BASE_REF
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/reusable-kubernetes.yaml
+++ b/.github/workflows/reusable-kubernetes.yaml
@@ -20,6 +20,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Add Safedir
+        run: git config --global --add safe.directory "/tmp"
+
       - name: Set up Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/reusable-kubernetes.yaml
+++ b/.github/workflows/reusable-kubernetes.yaml
@@ -36,9 +36,9 @@ jobs:
         id: validate
         run: go tool mage k8s:validate
 
-      - name: Kubernetes validation
+      - name: Kubernetes diff
         id: diff
-        run: go tool mage k8s:diff
+        run: go tool mage -v k8s:diff
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -190,7 +190,7 @@ func Worktree(branch string) (string, func(), error) {
 
 	// We use git worktree remove which cleans up the admin files and the directory.
 	cleanup := func() {
-		err = sh.Run("git", "worktree", "remove", targetDir)
+		err = sh.Run("git", "worktree", "remove", "--force", targetDir)
 		if err != nil {
 			fmt.Printf("Failed to delete %s, error %s", targetDir, err)
 		}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -183,7 +183,7 @@ func Worktree(branch string) (string, func(), error) {
 		return targetDir, cleanupDir, err
 	}
 	// Execute 'git worktree add <path> <branch>'
-	err = sh.Run("git", "worktree", "add", targetDir, branch)
+	err = sh.Run("git", "worktree", "add", targetDir, "--detach", branch)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to create worktree for branch %s: %w", branch, err)
 	}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -183,7 +183,7 @@ func Worktree(branch string) (string, func(), error) {
 		return targetDir, cleanupDir, err
 	}
 	// Execute 'git worktree add <path> <branch>'
-	err = sh.Run("git", "worktree", "add", targetDir, "--detach", branch)
+	err = sh.Run("git", "worktree", "add", "--detach", targetDir, branch)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to create worktree for branch %s: %w", branch, err)
 	}

--- a/internal/kubernetes/kubernetes.go
+++ b/internal/kubernetes/kubernetes.go
@@ -90,7 +90,7 @@ func RenderTemplates(chart HelmChart, dest string, try bool) error {
 	if err != nil {
 		return fmt.Errorf("failed to check dependencies. Please remove all contents %s/charts. Error: %s", chart.path, err)
 	}
-	if strings.Contains(depstatus, "missing") {
+	if !depStatusOK(depstatus) {
 		_, _, err := helm.Run(nil, path, "dep", "up", ".")
 		if err != nil {
 			return err
@@ -102,6 +102,29 @@ func RenderTemplates(chart HelmChart, dest string, try bool) error {
 		return os.WriteFile(dest, []byte(out), 0o644)
 	}
 	return err
+}
+
+func depStatusOK(input string) bool {
+	lines := strings.Split(strings.TrimSpace(input), "\n")
+	for i, line := range lines {
+		if i == 0 {
+			// skip header
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) != 3 {
+			// cheap check if the command produces a sensible result
+			return false
+		}
+
+		status := fields[len(fields)-1]
+		if status != "ok" {
+			return false
+		}
+	}
+
+	return true
 }
 
 // DiffTemplates will create a diff of the rendered templates of a helmchart


### PR DESCRIPTION
The status of the dependencies where validate in a bit of a mindless way.. causing some bugs if the status 'wrong'. Also using concurrency causes issues with git worktree, so now i made deteched worktrees to work around this problem. 