### PR TITLE
chore: Use amd64 hash instead of multi-arch one for terraform-docs

### DIFF
--- a/internal/devtool/tools.Dockerfile
+++ b/internal/devtool/tools.Dockerfile
@@ -5,6 +5,6 @@ FROM docker.io/palantirtechnologies/policy-bot:1.41.1@sha256:1babe4d474db1ed7184
 FROM docker.io/hashicorp/terraform:1.5.7@sha256:9fc0d70fb0f858b0af1fadfcf8b7510b1b61e8b35e7a4bb9ff39f7f6568c321d AS terraform
 FROM ghcr.io/terraform-linters/tflint:v0.61.0@sha256:b835d64d66abfdbc146694b918eb3cd733ec772465ad511464d4e8bebbdd6732 AS tflint
 FROM docker.io/aquasec/trivy:0.69.3@sha256:bcc376de8d77cfe086a917230e818dc9f8528e3c852f7b1aff648949b6258d1c AS trivy
-FROM quay.io/terraform-docs/terraform-docs:0.20.0@sha256:37329e2dc2518e7f719a986a3954b10771c3fe000f50f83fd4d98d489df2eae2 AS terraform-docs
+FROM quay.io/terraform-docs/terraform-docs:0.20.0@sha256:f185ad73cfffb958fded8f058f645955bb29f69d8fbb5a4e038c05eba9c7083f AS terraform-docs
 FROM docker.io/alpine/helm:3.20.2@sha256:0dc15c3084f75cdf39823f63efbe7c21084d2dbffefce2637effc1b093485d81 as helm
 FROM docker.io/zegl/kube-score:v1.20.0@sha256:ac4c43ad560af905d66f6bf57b0937c591332e6dbf2167c31193a13b4695ab97 as kube-score


### PR DESCRIPTION
Renovate is not updating this image, so trying this.