### PR TITLE
chore: Remove `pin@` from versions in gh actions version comment

### DIFF
--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -191,7 +191,7 @@ jobs:
         id: generate_token
         if: ${{ github.ref == 'refs/heads/main' && inputs.tag-based-diff }}
         # v1.5.1
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # pin@v2.2.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v2.2.1
         with:
           app-id: 172868
           private-key: ${{ secrets.WRITEBACK_APP_PRIVATE_KEY_PEM }}
@@ -208,7 +208,7 @@ jobs:
           fi
           echo "tag=$(echo $OCI_TAG)" >> $GITHUB_OUTPUT
 
-      - uses: release-drafter/release-drafter@c2e2804cc59f45f57076a99af580d0fedb697927 # pin@v7.2.0
+      - uses: release-drafter/release-drafter@c2e2804cc59f45f57076a99af580d0fedb697927 # v7.2.0
         name: Create release
         id: make-release
         if: ${{ github.ref == 'refs/heads/main' && inputs.tag-based-diff }}


### PR DESCRIPTION
This is preventing renovate updates