### PR TITLE
chore: Remove `go install tool` command from all workflows

### DIFF
--- a/.github/workflows/goapp.yaml
+++ b/.github/workflows/goapp.yaml
@@ -92,8 +92,6 @@ jobs:
           filters: |
             changed:
               - '**'
-      - name: Install go Tools
-        run: go install tool
       - name: List changes
         id: list
         run: go tool mage git:listChanges

--- a/.github/workflows/infrastructurerepo.yaml
+++ b/.github/workflows/infrastructurerepo.yaml
@@ -54,8 +54,6 @@ jobs:
           filters: |
             changed:
               - '**'
-      - name: Install go Tools
-        run: go install tool
       - name: List changes
         id: list
         run: go tool mage git:listChanges

--- a/.github/workflows/mage.yaml
+++ b/.github/workflows/mage.yaml
@@ -100,8 +100,6 @@ jobs:
         with:
           go-version: "stable"
           cache-dependency-path: "**/go.sum"
-      - name: Install go Tools
-        run: go install tool
       - name: Install OpenTofu
         if: ${{ inputs.opentofu-version != '' }}
         uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4 # v2

--- a/.github/workflows/reusable-catalog-info.yaml
+++ b/.github/workflows/reusable-catalog-info.yaml
@@ -23,9 +23,6 @@ jobs:
           go-version: "stable"
           cache-dependency-path: "**/go.sum"
 
-      - name: Install go Tools
-        run: go install tool
-
       - name: Catalog Info Validation
         id: validate
         run: go tool mage catalogInfo:validate

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -55,8 +55,6 @@ jobs:
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
           install-only: true
-      - name: Install go Tools
-        run: go install tool
       - name: Check if coop mage has separeate build commands
         id: has-multiple-cmds
         run: echo "outcome=$(go tool mage -l | grep go:buildBinaries | wc -l)" >> $GITHUB_OUTPUT
@@ -84,8 +82,6 @@ jobs:
         with:
           go-version: "stable"
           cache-dependency-path: "**/go.sum"
-      - name: Install go Tools
-        run: go install tool
       - name: Check if coop mage has separate build commands
         id: has-multiple-cmds
         run: echo "outcome=$(go tool mage -l | grep go:buildBinaries | wc -l)" >> $GITHUB_OUTPUT
@@ -151,8 +147,6 @@ jobs:
         with:
           go-version: "stable"
           cache-dependency-path: "**/go.sum"
-      - name: Install go Tools
-        run: go install tool
       - name: Check if coop mage has separate build commands
         id: has-multiple-cmds
         run: echo "outcome=$(go tool mage -l | grep go:buildBinaries | wc -l)" >> $GITHUB_OUTPUT

--- a/.github/workflows/reusable-kubernetes.yaml
+++ b/.github/workflows/reusable-kubernetes.yaml
@@ -28,8 +28,6 @@ jobs:
         with:
           go-version: "stable"
           cache-dependency-path: "**/go.sum"
-      - name: Install go Tools
-        run: go install tool
 
       - name: Kubernetes List Detected charts
         id: list

--- a/.github/workflows/reusable-pallets.yaml
+++ b/.github/workflows/reusable-pallets.yaml
@@ -22,8 +22,6 @@ jobs:
         with:
           go-version: "stable"
           cache-dependency-path: "**/go.sum"
-      - name: Install go Tools
-        run: go install tool
 
       - name: Pallet config validation
         id: validate

--- a/.github/workflows/reusable-policy-bot.yaml
+++ b/.github/workflows/reusable-policy-bot.yaml
@@ -22,8 +22,6 @@ jobs:
         with:
           go-version: "stable"
           cache-dependency-path: "**/go.sum"
-      - name: Install go Tools
-        run: go install tool
 
       - name: Policy-bot config validation
         id: validate

--- a/.github/workflows/reusable-terraform.yaml
+++ b/.github/workflows/reusable-terraform.yaml
@@ -81,8 +81,6 @@ jobs:
         with:
           go-version: "stable"
           cache-dependency-path: "**/go.sum"
-      - name: Install go Tools
-        run: go install tool
 
       - name: Terraform Init
         id: init


### PR DESCRIPTION
It seems that this command is redundant (i.e. running `go tool x` installs it automatically) and adds a lot to the CI time:

with go install tool (before this change):
- total runtime: 23m 6s
ref: https://github.com/coopnorge/membership-deposit-management/actions/runs/29739609369

without go install tool (after this change):
- total runtime: 11m 35s
ref: https://github.com/coopnorge/membership-deposit-management/actions/runs/29743568552?pr=3455