### PR TITLE
feat: Support for `opentofu-version` in all workflows

### DIFF
--- a/.github/workflows/goapp.yaml
+++ b/.github/workflows/goapp.yaml
@@ -56,6 +56,10 @@ on:
         type: boolean
         default: false
         description: Cleanup diskspace before init. This is useful for very large projects, but add 1 minute extra job time.
+      opentofu-version:
+        type: string
+        default: ""
+        description: If set, install this version of OpenTofu and set USE_TOFU=1 so mage uses the tofu devtool instead of terraform.
 
     outputs:
       oci-images:
@@ -165,6 +169,7 @@ jobs:
       skip-terraform-if-dir-has-no-changes: ${{ inputs.terraform-skip-if-dir-has-no-changes }}
       suggest-formatting-fixes: ${{ inputs.terraform-suggest-formatting-fixes }}
       cleanup-diskspace: ${{ inputs.terraform-cleanup-diskspace }}
+      opentofu-version: ${{ inputs.opentofu-version }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/infrastructurerepo.yaml
+++ b/.github/workflows/infrastructurerepo.yaml
@@ -25,6 +25,10 @@ on:
         type: boolean
         default: false
         description: Cleanup diskspace before init. This is useful for very large projects, but add 1 minute extra job time.
+      opentofu-version:
+        type: string
+        default: ""
+        description: If set, install this version of OpenTofu and set USE_TOFU=1 so mage uses the tofu devtool instead of terraform.
 
 jobs:
   detect-changes:
@@ -88,6 +92,7 @@ jobs:
       skip-terraform-if-dir-has-no-changes: ${{ inputs.skip-terraform-if-dir-has-no-changes }}
       suggest-formatting-fixes: ${{ inputs.terraform-suggest-formatting-fixes }}
       cleanup-diskspace: ${{ inputs.terraform-cleanup-diskspace }}
+      opentofu-version: ${{ inputs.opentofu-version }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/reusable-terraform.yaml
+++ b/.github/workflows/reusable-terraform.yaml
@@ -20,12 +20,18 @@ on:
         type: boolean
         default: false
         description: Cleanup diskspace before init. This is useful for very large projects, but add 1 minute extra job time.
+      opentofu-version:
+        type: string
+        default: ""
+        description: If set, install this version of OpenTofu and set USE_TOFU=1 so mage uses the tofu devtool instead of terraform.  
     secrets: {}
 
 jobs:
   validate-terraform:
     name: Terraform CI
     runs-on: ubuntu-24.04
+    env:
+      USE_TOFU: ${{ inputs.opentofu-version != '' && 'true' || '' }}
     permissions:
       contents: read
       issues: write
@@ -54,7 +60,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install OpenTofu
+        if: ${{ inputs.opentofu-version != '' }}
+        uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4 # v2
+        with:
+          tofu_version: ${{ inputs.opentofu-version }}
+          tofu_wrapper: false
+
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
+        if: ${{ inputs.opentofu-version == '' }}
         with:
           terraform_wrapper: false
           terraform_version: "1.5.7"


### PR DESCRIPTION
was missed here: https://github.com/coopnorge/mage/pull/655
