### PR TITLE
feat: Allow using OpenTofu instead of Terraform in goapp and infrastructure repo workflows

### DIFF
--- a/.github/workflows/goapp.yaml
+++ b/.github/workflows/goapp.yaml
@@ -56,6 +56,10 @@ on:
         type: boolean
         default: false
         description: Cleanup diskspace before init. This is useful for very large projects, but add 1 minute extra job time.
+      opentofu-version:
+        type: string
+        default: ""
+        description: If set, install this version of OpenTofu and set USE_TOFU=true so mage uses the tofu devtool instead of terraform.
 
     outputs:
       oci-images:
@@ -165,6 +169,7 @@ jobs:
       skip-terraform-if-dir-has-no-changes: ${{ inputs.terraform-skip-if-dir-has-no-changes }}
       suggest-formatting-fixes: ${{ inputs.terraform-suggest-formatting-fixes }}
       cleanup-diskspace: ${{ inputs.terraform-cleanup-diskspace }}
+      opentofu-version: ${{ inputs.opentofu-version }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/infrastructurerepo.yaml
+++ b/.github/workflows/infrastructurerepo.yaml
@@ -25,6 +25,10 @@ on:
         type: boolean
         default: false
         description: Cleanup diskspace before init. This is useful for very large projects, but add 1 minute extra job time.
+      opentofu-version:
+        type: string
+        default: ""
+        description: If set, install this version of OpenTofu and set USE_TOFU=true so mage uses the tofu devtool instead of terraform.
 
 jobs:
   detect-changes:
@@ -88,6 +92,7 @@ jobs:
       skip-terraform-if-dir-has-no-changes: ${{ inputs.skip-terraform-if-dir-has-no-changes }}
       suggest-formatting-fixes: ${{ inputs.terraform-suggest-formatting-fixes }}
       cleanup-diskspace: ${{ inputs.terraform-cleanup-diskspace }}
+      opentofu-version: ${{ inputs.opentofu-version }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/mage.yaml
+++ b/.github/workflows/mage.yaml
@@ -28,7 +28,7 @@ on:
       opentofu-version:
         type: string
         default: ""
-        description: If set, install this version of OpenTofu and set USE_TOFU=1 so mage uses the tofu devtool instead of terraform.
+        description: If set, install this version of OpenTofu and set USE_TOFU=true so mage uses the tofu devtool instead of terraform.
     outputs:
       oci-images:
         value: ${{ jobs.mage.outputs.oci-images }}

--- a/.github/workflows/reusable-terraform.yaml
+++ b/.github/workflows/reusable-terraform.yaml
@@ -34,6 +34,8 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
+    env:
+      USE_TOFU: ${{ inputs.opentofu-version != '' && 'true' || '' }}
     steps:
       - name: Cleanup Disk Space
         if: ${{ inputs.cleanup-diskspace == true }}
@@ -99,15 +101,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.REVIEWBOT_GITHUB_TOKEN }}
           TERRAFORM_SKIP_IF_NO_CHANGES_IN_DIR: ${{ inputs.skip-terraform-if-dir-has-no-changes }}
-          USE_TOFU: ${{ inputs.opentofu-version != '' && 'true' || '' }}
 
       - name: Terraform Lint fix
         if: ${{ inputs.suggest-formatting-fixes == true }}
         id: lint-fix
         continue-on-error: true
         run: go tool mage terraform:lintFix
-        env:
-          USE_TOFU: ${{ inputs.opentofu-version != '' && 'true' || '' }}
 
       - name: Add review suggestions
         if: ${{ inputs.suggest-formatting-fixes == true }}
@@ -122,7 +121,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.REVIEWBOT_GITHUB_TOKEN }}
           TERRAFORM_SKIP_IF_NO_CHANGES_IN_DIR: ${{ inputs.skip-terraform-if-dir-has-no-changes }}
-          USE_TOFU: ${{ inputs.opentofu-version != '' && 'true' || '' }}
 
       - name: Code Test
         id: test
@@ -130,7 +128,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.REVIEWBOT_GITHUB_TOKEN }}
           TERRAFORM_SKIP_IF_NO_CHANGES_IN_DIR: ${{ inputs.skip-terraform-if-dir-has-no-changes }}
-          USE_TOFU: ${{ inputs.opentofu-version != '' && 'true' || '' }}
 
       - name: Code Security
         id: security
@@ -138,7 +135,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.REVIEWBOT_GITHUB_TOKEN }}
           TERRAFORM_SKIP_IF_NO_CHANGES_IN_DIR: ${{ inputs.skip-terraform-if-dir-has-no-changes }}
-          USE_TOFU: ${{ inputs.opentofu-version != '' && 'true' || '' }}
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/reusable-terraform.yaml
+++ b/.github/workflows/reusable-terraform.yaml
@@ -20,6 +20,10 @@ on:
         type: boolean
         default: false
         description: Cleanup diskspace before init. This is useful for very large projects, but add 1 minute extra job time.
+      opentofu-version:
+        type: string
+        default: ""
+        description: If set, install this version of OpenTofu and set USE_TOFU=true so mage uses the tofu devtool instead of terraform.
     secrets: {}
 
 jobs:
@@ -59,6 +63,13 @@ jobs:
           terraform_wrapper: false
           terraform_version: "1.5.7"
 
+      - name: Install OpenTofu
+        if: ${{ inputs.opentofu-version != '' }}
+        uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4 # v2
+        with:
+          tofu_version: ${{ inputs.opentofu-version }}
+          tofu_wrapper: false
+
       - name: "Setup Spacelift Credentials"
         run: |
           set -x
@@ -88,12 +99,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.REVIEWBOT_GITHUB_TOKEN }}
           TERRAFORM_SKIP_IF_NO_CHANGES_IN_DIR: ${{ inputs.skip-terraform-if-dir-has-no-changes }}
+          USE_TOFU: ${{ inputs.opentofu-version != '' && 'true' || '' }}
 
       - name: Terraform Lint fix
         if: ${{ inputs.suggest-formatting-fixes == true }}
         id: lint-fix
         continue-on-error: true
         run: go tool mage terraform:lintFix
+        env:
+          USE_TOFU: ${{ inputs.opentofu-version != '' && 'true' || '' }}
 
       - name: Add review suggestions
         if: ${{ inputs.suggest-formatting-fixes == true }}
@@ -108,6 +122,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.REVIEWBOT_GITHUB_TOKEN }}
           TERRAFORM_SKIP_IF_NO_CHANGES_IN_DIR: ${{ inputs.skip-terraform-if-dir-has-no-changes }}
+          USE_TOFU: ${{ inputs.opentofu-version != '' && 'true' || '' }}
 
       - name: Code Test
         id: test
@@ -115,6 +130,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.REVIEWBOT_GITHUB_TOKEN }}
           TERRAFORM_SKIP_IF_NO_CHANGES_IN_DIR: ${{ inputs.skip-terraform-if-dir-has-no-changes }}
+          USE_TOFU: ${{ inputs.opentofu-version != '' && 'true' || '' }}
 
       - name: Code Security
         id: security
@@ -122,6 +138,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.REVIEWBOT_GITHUB_TOKEN }}
           TERRAFORM_SKIP_IF_NO_CHANGES_IN_DIR: ${{ inputs.skip-terraform-if-dir-has-no-changes }}
+          USE_TOFU: ${{ inputs.opentofu-version != '' && 'true' || '' }}
 
       - name: Cleanup
         if: always()


### PR DESCRIPTION
Does not change defaults, so still uses terraform by default.
