### PR TITLE
feat: add ability to skip lint and test jobs on main

### DIFF
--- a/.github/workflows/goapp.yaml
+++ b/.github/workflows/goapp.yaml
@@ -60,6 +60,11 @@ on:
         type: string
         default: ""
         description: If set, install this version of OpenTofu and set USE_TOFU=true so mage uses the tofu devtool instead of terraform.
+      skip-lint-and-test-on-main:
+        type: boolean
+        default: false
+        required: false
+        description: If set to true, skip the Lint and Test jobs on the main branch. Lint and Test will still run on pull requests and other branches.
 
     outputs:
       oci-images:
@@ -159,6 +164,7 @@ jobs:
       service-account: ${{ inputs.service-account }}
       artifact-registry-location: ${{ inputs.artifact-registry-location }}
       tag-based-diff: ${{ inputs.tag-based-diff }}
+      skip-lint-and-test-on-main: ${{ inputs.skip-lint-and-test-on-main }}
 
   terraform:
     name: Terraform

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -116,10 +116,7 @@ jobs:
 
   go-build-and-push:
     name: Go build and push
-    needs:
-      - go-lint
-      - go-test
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ always() && github.ref == 'refs/heads/main' && (inputs.skip-lint-and-test-on-main || (needs.go-lint.result == 'success' && needs.go-test.result == 'success')) }}
     uses: ./.github/workflows/reusable-goapp-build.yaml
     permissions:
       contents: write

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -30,6 +30,11 @@ on:
         default: true
         required: false
         description: If true it will create a github release based on the tag of the OCI
+      skip-lint-and-test-on-main:
+        type: boolean
+        default: false
+        required: false
+        description: If set to true, skip the Lint and Test jobs on the main branch. Will still run on pull requests and other branches.
     outputs:
       oci-images:
         value: ${{ jobs.go-build-and-push.outputs.oci-images || '{}' }}
@@ -38,6 +43,7 @@ on:
 jobs:
   go-lint:
     name: Go Lint
+    if: ${{ github.ref != 'refs/heads/main' || inputs.skip-lint-and-test-on-main == false }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -69,6 +75,7 @@ jobs:
 
   go-test:
     name: Go Test
+    if: ${{ github.ref != 'refs/heads/main' || inputs.skip-lint-and-test-on-main == false }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -116,6 +116,9 @@ jobs:
 
   go-build-and-push:
     name: Go build and push
+    needs:
+      - go-lint
+      - go-test
     if: ${{ always() && github.ref == 'refs/heads/main' && (inputs.skip-lint-and-test-on-main || (needs.go-lint.result == 'success' && needs.go-test.result == 'success')) }}
     uses: ./.github/workflows/reusable-goapp-build.yaml
     permissions:


### PR DESCRIPTION
Add the ability for consumers to decide if they would like to run lint and test on main.

Most of (maybe all?) our Go project repos has a branch protection rule that removes direct pushes on main,
resulting in the need to create pull requests for each change. This is good!
If we then require a Lint and Test job to be ran on the feature branch before merge, this then removes the need for
running the same checks on main.

This is an attept to save deployment time on bigger projects.
