### PR TITLE
feat: Set the golangci-lint version in github actions

### DIFF
--- a/.github/actions/go-fix/action.yaml
+++ b/.github/actions/go-fix/action.yaml
@@ -45,6 +45,7 @@ runs:
       uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
       with:
         install-only: true
+        version: v2.12.2 # renovate: datasource=docker depName=golangci/golangci-lint
 
     - name: Run go:fix
       shell: bash

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,6 +4,17 @@
         "github>coopnorge/github-workflow-renovate",
     ],
     "customManagers": [
+        // golangci-lint version in GitHub Actions workflows, kept in sync with tools.Dockerfile
+        {
+            "customType": "regex",
+            "managerFilePatterns": ["/^\\.github/(workflows|actions)/.+\\.yaml$/"],
+            "matchStrings": [
+                "version:\\s+(?<currentValue>v[\\d.]+)\\s+# renovate: datasource=docker depName=golangci/golangci-lint"
+            ],
+            "datasourceTemplate": "docker",
+            "depNameTemplate": "golangci/golangci-lint",
+            "versioningTemplate": "semver",
+        },
         // backstage entity validator version in Dockerfile
         {
             "customType": "regex",

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -61,6 +61,7 @@ jobs:
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
           install-only: true
+          version: v2.12.2 # renovate: datasource=docker depName=golangci/golangci-lint
       - name: Check if coop mage has separeate build commands
         id: has-multiple-cmds
         run: echo "outcome=$(go tool mage -l | grep go:buildBinaries | wc -l)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
These versions will be kept in sync with a custom manager in Renvoate.

This will prevent a newer version being installed automatically, before the mage-tooling is ready for it, leading it to try to use the docker-version instead.