### PR TITLE
feat: Enable `errorlint` linter rule for Go

### DIFF
--- a/internal/core/cmd.go
+++ b/internal/core/cmd.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -191,7 +192,7 @@ func ExecAt(env map[string]string, stdout, stderr io.Writer, pwd string, cmd str
 	if ran {
 		return ran, mg.Fatalf(code, `running "%s %s" failed with exit code %d`, cmd, strings.Join(args, " "), code)
 	}
-	return ran, fmt.Errorf(`failed to run "%s %s: %v"`, cmd, strings.Join(args, " "), err)
+	return ran, fmt.Errorf(`failed to run "%s %s: %w"`, cmd, strings.Join(args, " "), err)
 }
 
 func run(env map[string]string, stdout, stderr io.Writer, pwd string, cmd string, args ...string) (ran bool, code int, err error) {
@@ -227,8 +228,7 @@ func CmdRan(err error) bool {
 	if err == nil {
 		return true
 	}
-	ee, ok := err.(*exec.ExitError)
-	if ok {
+	if ee, ok := errors.AsType[*exec.ExitError](err); ok {
 		return ee.Exited()
 	}
 	return false
@@ -248,8 +248,9 @@ func ExitStatus(err error) int {
 	if e, ok := err.(exitStatus); ok {
 		return e.ExitStatus()
 	}
-	if e, ok := err.(*exec.ExitError); ok {
-		if ex, ok := e.Sys().(exitStatus); ok {
+
+	if ee, ok := errors.AsType[*exec.ExitError](err); ok {
+		if ex, ok := ee.Sys().(exitStatus); ok {
 			return ex.ExitStatus()
 		}
 	}

--- a/internal/devtool/golangci-lint/golangci-lint.yml
+++ b/internal/devtool/golangci-lint/golangci-lint.yml
@@ -14,6 +14,7 @@ linters:
     - unused
     - whitespace
     - reassign
+    - errorlint
   settings:
     errcheck:
       check-type-assertions: true

--- a/internal/kubernetes/kubernetes.go
+++ b/internal/kubernetes/kubernetes.go
@@ -88,7 +88,7 @@ func RenderTemplates(chart HelmChart, dest string, try bool) error {
 	// make sure dependencies are there
 	depstatus, _, err := helm.Run(nil, path, "dep", "list", ".")
 	if err != nil {
-		return fmt.Errorf("failed to check dependencies. Please remove all contents %s/charts. Error: %s", chart.path, err)
+		return fmt.Errorf("failed to check dependencies. Please remove all contents %s/charts. Error: %w", chart.path, err)
 	}
 	if !depStatusOK(depstatus) {
 		_, _, err := helm.Run(nil, path, "dep", "up", ".")


### PR DESCRIPTION
This linter ensures that we are handling errors in a Go 1.13-compatible way, with correct wrapping and unwrapping.

Reference: https://golangci-lint.run/docs/linters/configuration/#errorlint

Closes https://github.com/coopnorge/mage/issues/701
