### PR TITLE
fix: Check out correct main branch

### DIFF
--- a/.github/workflows/reusable-kubernetes.yaml
+++ b/.github/workflows/reusable-kubernetes.yaml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
 
       - name: Fetch the main branch as well
-        run: git fetch origin $GITHUB_BASE_REF:$GITHUB_BASE_REF
+        run: git fetch origin main:main
 
       - name: Set up Go
         uses: actions/setup-go@v7


### PR DESCRIPTION
Fetching "GITHUB_BASE_REF" would lead to `main` not being present to diff against, so `Kubernetes diff` would fail for stacked PRs.

The Kubernetes diffing is hardcoded to diff against main: https://github.com/coopnorge/mage/blob/allow-validate-kubernetes-in-stacked-prs/internal/kubernetes/kubernetes.go#L148