### PR TITLE
exclude helm labels with versions in diff

### DIFF
--- a/internal/kubernetes/kubernetes.go
+++ b/internal/kubernetes/kubernetes.go
@@ -166,6 +166,8 @@ func DiffTemplates(chart HelmChart) error {
 		"--color", "on",
 		"--truecolor", "on",
 		"between",
+		// ignore diff on label metadata.labels.helm.sh/chart
+		"--exclude-regexp", `.*helm.sh/chart`,
 	}
 	if github.InCI() {
 		args = append(args, "--output", "github")


### PR DESCRIPTION
This will remove all the helm chart version label diffs from the diff. This will make it more readable. 

```
metadata.labels.helm.sh/chart  (v1/Service/store-information-service)
  ± value change
    - coop-app-chart-0.43.0
    + coop-app-chart-0.43.1-alpha.350.1282

metadata.labels.helm.sh/chart  (apps/v1/Deployment/store-information-service)
  ± value change
    - coop-app-chart-0.43.0
    + coop-app-chart-0.43.1-alpha.350.1282

metadata.labels.helm.sh/chart  (autoscaling/v2/HorizontalPodAutoscaler/store-information-service)
  ± value change
    - coop-app-chart-0.43.0
    + coop-app-chart-0.43.1-alpha.350.1282

metadata.labels.helm.sh/chart  (external-secrets.io/v1beta1/ExternalSecret/store-information-service)
  ± value change
    - coop-app-chart-0.43.0
    + coop-app-chart-0.43.1-alpha.350.1282

```

Signed-off-by: Atze de Vries <atze.wiebe.de.vries@coop.no>
