### PR TITLE
ci: Add caching of golangci-lint results

### DIFF
--- a/.github/actions/go-fix/action.yaml
+++ b/.github/actions/go-fix/action.yaml
@@ -48,6 +48,12 @@ runs:
         install-only: true
         version: v2.13.0 # renovate: datasource=docker depName=golangci/golangci-lint
 
+    - name: Cache golangci-lint analysis cache
+      uses: actions/cache@v6
+      with:
+        path: ~/.cache/golangci-lint
+        key: "golangci-lint-v2.13.0" # renovate: datasource=docker depName=golangci/golangci-lint
+
     - name: Run go:fix
       shell: bash
       run: |

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,6 +15,17 @@
             "depNameTemplate": "golangci/golangci-lint",
             "versioningTemplate": "semver",
         },
+        // golangci-lint version in GitHub Actions cache keys
+        {
+            "customType": "regex",
+            "managerFilePatterns": ["/^\\.github/(workflows|actions)/.+\\.yaml$/"],
+            "matchStrings": [
+                "key: \\s+\\"golangci-lint-(?<currentValue>v[\\d.]+)\\"\\s+# renovate: datasource=docker depName=golangci/golangci-lint"
+            ],
+            "datasourceTemplate": "docker",
+            "depNameTemplate": "golangci/golangci-lint",
+            "versioningTemplate": "semver",
+        },
         // docker.io/library/golang version in GitHub Actions workflows, kept in sync with tools.Dockerfile
         {
             "customType": "regex",

--- a/.github/workflows/reusable-goapp.yaml
+++ b/.github/workflows/reusable-goapp.yaml
@@ -62,6 +62,11 @@ jobs:
         with:
           install-only: true
           version: v2.13.0 # renovate: datasource=docker depName=golangci/golangci-lint
+      - name: Cache golangci-lint analysis cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/golangci-lint
+          key: "golangci-lint-v2.13.0" # renovate: datasource=docker depName=golangci/golangci-lint
       - name: Check if coop mage has separeate build commands
         id: has-multiple-cmds
         run: echo "outcome=$(go tool mage -l | grep go:buildBinaries | wc -l)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
By caching the `~/.cache/golangci-lint`, we should get faster runs.

On my Mac, with a warm GOCACHE and GOMODCACHE, but with a cold/warm golangci-lint cache, I was able to shave off around ~46 seconds in a real repo, and my Mac is a lot beefier than the CI-runners (even ubuntu-latest), to it should amount to a big difference there.

Ref: https://golangci-lint.run/docs/configuration/cli/#cache
